### PR TITLE
Fix Inspect Code Warnings

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -40,7 +40,7 @@ configurations {
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
-    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.0.1'
+    implementation 'org.jetbrains.kotlinx:kotlinx-coroutines-android:1.1.0'
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.appcompat:appcompat:1.0.2'
     implementation "androidx.legacy:legacy-support-v4:$ax_version"
@@ -52,7 +52,7 @@ dependencies {
     implementation 'com.google.code.gson:gson:2.8.2'
     implementation 'com.github.markusfisch:ScalingImageView:1.1.2'
     implementation 'com.squareup.picasso:picasso:2.71828'
-    implementation 'com.squareup.okhttp3:okhttp:3.10.0'
+    implementation 'com.squareup.okhttp3:okhttp:3.11.0'
     testImplementation 'junit:junit:4.12'
     ktlint "com.github.shyiko:ktlint:0.29.0"
 }

--- a/app/src/main/kotlin/de/cineaste/android/MainActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/MainActivity.kt
@@ -88,7 +88,8 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
                 Toast.makeText(
                     this,
                     R.string.missing_permission,
-                    Toast.LENGTH_SHORT).show()
+                    Toast.LENGTH_SHORT
+                ).show()
             }
             else -> {
             }
@@ -129,7 +130,8 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
         fm.beginTransaction()
             .replace(
                 R.id.content_container,
-                fragment, fragment.javaClass.name)
+                fragment, fragment.javaClass.name
+            )
             .addToBackStack(null)
             .commit()
     }
@@ -186,7 +188,12 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
 
             if (menuItem.title != null) {
                 val spanString = SpannableString(menuItem.title.toString())
-                spanString.setSpan(ForegroundColorSpan(ContextCompat.getColor(this, R.color.toolbar_text)), 0, spanString.length, 0)
+                spanString.setSpan(
+                    ForegroundColorSpan(ContextCompat.getColor(this, R.color.toolbar_text)),
+                    0,
+                    spanString.length,
+                    0
+                )
                 menuItem.title = spanString
             }
 
@@ -352,7 +359,8 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
         val bundle = Bundle()
         bundle.putString(
             WatchState.WATCH_STATE_TYPE.name,
-            state.name)
+            state.name
+        )
         watchlistFragment.arguments = bundle
         return watchlistFragment
     }
@@ -362,7 +370,8 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
         val bundle = Bundle()
         bundle.putString(
             WatchState.WATCH_STATE_TYPE.name,
-            state.name)
+            state.name
+        )
         seriesListFragment.arguments = bundle
         return seriesListFragment
     }

--- a/app/src/main/kotlin/de/cineaste/android/MainActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/MainActivity.kt
@@ -84,7 +84,9 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
         grantResults: IntArray
     ) {
         when (requestCode) {
-            1 -> if (grantResults.isNotEmpty() && grantResults[0] != PackageManager.PERMISSION_GRANTED) {
+            1 -> if (grantResults.isNotEmpty() &&
+                grantResults[0] != PackageManager.PERMISSION_GRANTED
+            ) {
                 Toast.makeText(
                     this,
                     R.string.missing_permission,
@@ -113,7 +115,10 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
         checkPermissions()
 
         if (savedInstanceState == null) {
-            replaceFragment(fm, getBaseWatchlistFragment(WatchState.WATCH_STATE))
+            replaceFragment(
+                fm,
+                getBaseWatchlistFragment(WatchState.WATCH_STATE)
+            )
         }
     }
 
@@ -136,13 +141,19 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
             .commit()
     }
 
-    private fun replaceFragmentPopBackStack(fm: FragmentManager, fragment: Fragment) {
+    private fun replaceFragmentPopBackStack(
+        fm: FragmentManager,
+        fragment: Fragment
+    ) {
         fm.popBackStack()
         replaceFragment(fm, fragment)
     }
 
     private fun checkPermissions() {
-        val permissions = arrayOf(Manifest.permission.READ_EXTERNAL_STORAGE, Manifest.permission.WRITE_EXTERNAL_STORAGE)
+        val permissions = arrayOf(
+            Manifest.permission.READ_EXTERNAL_STORAGE,
+            Manifest.permission.WRITE_EXTERNAL_STORAGE
+        )
 
         val listPermissionsNeeded = ArrayList<String>()
         for (p in permissions) {
@@ -153,7 +164,11 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
         }
 
         if (listPermissionsNeeded.isNotEmpty()) {
-            ActivityCompat.requestPermissions(this, listPermissionsNeeded.toTypedArray(), 1)
+            ActivityCompat.requestPermissions(
+                this,
+                listPermissionsNeeded.toTypedArray(),
+                1
+            )
         }
     }
 
@@ -167,7 +182,9 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
 
     private fun initNavDrawer() {
         val navigationView = findViewById<NavigationView>(R.id.navigation_view)
-        navigationView.setNavigationItemSelectedListener(CustomDrawerClickListener())
+        navigationView.setNavigationItemSelectedListener(
+            CustomDrawerClickListener()
+        )
 
         colorMenu(navigationView.menu)
 
@@ -189,7 +206,12 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
             if (menuItem.title != null) {
                 val spanString = SpannableString(menuItem.title.toString())
                 spanString.setSpan(
-                    ForegroundColorSpan(ContextCompat.getColor(this, R.color.toolbar_text)),
+                    ForegroundColorSpan(
+                        ContextCompat.getColor(
+                            this,
+                            R.color.toolbar_text
+                        )
+                    ),
                     0,
                     spanString.length,
                     0
@@ -200,7 +222,12 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
             val drawable = menuItem.icon
             if (drawable != null) {
                 drawable.mutate()
-                drawable.setColorFilter(ContextCompat.getColor(this, R.color.colorPrimary), PorterDuff.Mode.SRC_ATOP)
+                drawable.setColorFilter(
+                    ContextCompat.getColor(
+                        this,
+                        R.color.colorPrimary
+                    ), PorterDuff.Mode.SRC_ATOP
+                )
             }
 
             val subMenu = menuItem.subMenu
@@ -210,29 +237,35 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
         }
     }
 
-    private inner class CustomDrawerClickListener : NavigationView.OnNavigationItemSelectedListener {
+    private inner class CustomDrawerClickListener :
+        NavigationView.OnNavigationItemSelectedListener {
         override fun onNavigationItemSelected(item: MenuItem): Boolean {
             when (item.itemId) {
                 R.id.show_movie_watchlist -> {
-                    val watchlistFragment = getBaseWatchlistFragment(WatchState.WATCH_STATE)
+                    val watchlistFragment =
+                        getBaseWatchlistFragment(WatchState.WATCH_STATE)
                     replaceFragmentPopBackStack(fm, watchlistFragment)
                 }
                 R.id.show_movie_watchedlist -> {
-                    val historyFragment = getBaseWatchlistFragment(WatchState.WATCHED_STATE)
+                    val historyFragment =
+                        getBaseWatchlistFragment(WatchState.WATCHED_STATE)
                     replaceFragmentPopBackStack(fm, historyFragment)
                 }
                 R.id.show_series_watchlist -> {
-                    val seriesWatchlistFragment = getSeriesListFragment(WatchState.WATCH_STATE)
+                    val seriesWatchlistFragment =
+                        getSeriesListFragment(WatchState.WATCH_STATE)
                     replaceFragmentPopBackStack(fm, seriesWatchlistFragment)
                 }
                 R.id.show_series_watchedlist -> {
-                    val seriesHistoryFragment = getSeriesListFragment(WatchState.WATCHED_STATE)
+                    val seriesHistoryFragment =
+                        getSeriesListFragment(WatchState.WATCHED_STATE)
                     replaceFragmentPopBackStack(fm, seriesHistoryFragment)
                 }
                 R.id.exportMovies -> createExportFile()
                 R.id.importMovies -> selectImportFile()
                 R.id.about -> {
-                    val intent = Intent(this@MainActivity, AboutActivity::class.java)
+                    val intent =
+                        Intent(this@MainActivity, AboutActivity::class.java)
                     startActivity(intent)
                 }
             }
@@ -261,7 +294,8 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
         importExportObject.movies = movieDbHelper.readAllMovies()
         importExportObject.series = seriesDbHelper.allSeries
 
-        val successfullyExported = ExportService.export(importExportObject, uri, this@MainActivity)
+        val successfullyExported =
+            ExportService.export(importExportObject, uri, this@MainActivity)
 
         var snackBarMessage = R.string.exportFailed
 
@@ -303,7 +337,8 @@ class MainActivity : AppCompatActivity(), UserInputFragment.UserNameListener {
         baseListFragment.progressbar.visibility = View.VISIBLE
 
         GlobalScope.launch {
-            val importExportObject = ImportService.importFiles(uri, this@MainActivity)
+            val importExportObject =
+                ImportService.importFiles(uri, this@MainActivity)
             // todo find a better solution to save all files
             for (movie in importExportObject.movies) {
                 movieDbHelper.createOrUpdate(movie)

--- a/app/src/main/kotlin/de/cineaste/android/activity/AboutActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/AboutActivity.kt
@@ -19,7 +19,7 @@ class AboutActivity : AppCompatActivity() {
 
         initToolbar()
 
-        val webView = findViewById<WebView>(R.id.webview)
+        val webView = findViewById<WebView>(R.id.webView)
         webView.settings.javaScriptEnabled = true
         webView.addJavascriptInterface(WebInterface(resources), "Android")
         webView.loadUrl("file:///android_res/raw/about.html")

--- a/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
@@ -181,9 +181,9 @@ abstract class AbstractSearchActivity : AppCompatActivity(), ItemClickListener {
     }
 
     private fun showNetworkError() {
-        val snackbar = Snackbar
+        val snackBar = Snackbar
             .make(recyclerView, R.string.noInternet, Snackbar.LENGTH_LONG)
-        snackbar.show()
+        snackBar.show()
     }
 
     override fun onStop() {

--- a/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
@@ -147,7 +147,7 @@ abstract class AbstractSearchActivity : AppCompatActivity(), ItemClickListener {
 
                 override fun onQueryTextChange(query: String): Boolean {
                     var myQuery = query
-                    if (!myQuery.isEmpty()) {
+                    if (myQuery.isNotEmpty()) {
                         myQuery = myQuery.replace(" ", "+")
                         progressBar.visibility = View.VISIBLE
 

--- a/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
@@ -67,7 +67,7 @@ abstract class AbstractSearchActivity : AppCompatActivity(), ItemClickListener {
     override fun onItemClickListener(itemId: Long, views: Array<View>) {
         val intent = getIntentForDetailActivity(itemId)
 
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             val options = ActivityOptions.makeSceneTransitionAnimation(this,
                     Pair.create(views[0], "card"),
                     Pair.create(views[1], "poster"))

--- a/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
@@ -68,9 +68,11 @@ abstract class AbstractSearchActivity : AppCompatActivity(), ItemClickListener {
         val intent = getIntentForDetailActivity(itemId)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            val options = ActivityOptions.makeSceneTransitionAnimation(this,
-                    Pair.create(views[0], "card"),
-                    Pair.create(views[1], "poster"))
+            val options = ActivityOptions.makeSceneTransitionAnimation(
+                this,
+                Pair.create(views[0], "card"),
+                Pair.create(views[1], "poster")
+            )
             this.startActivity(intent, options.toBundle())
         } else {
             this.startActivity(intent)
@@ -91,8 +93,10 @@ abstract class AbstractSearchActivity : AppCompatActivity(), ItemClickListener {
         recyclerView = findViewById(R.id.search_recycler_view)
         val layoutManager = LinearLayoutManager(this)
         val divider = ContextCompat.getDrawable(recyclerView.context, R.drawable.divider)
-        val itemDecor = DividerItemDecoration(recyclerView.context,
-            layoutManager.orientation)
+        val itemDecor = DividerItemDecoration(
+            recyclerView.context,
+            layoutManager.orientation
+        )
         divider?.let {
             itemDecor.setDrawable(it)
         }
@@ -178,7 +182,7 @@ abstract class AbstractSearchActivity : AppCompatActivity(), ItemClickListener {
 
     private fun showNetworkError() {
         val snackbar = Snackbar
-                .make(recyclerView, R.string.noInternet, Snackbar.LENGTH_LONG)
+            .make(recyclerView, R.string.noInternet, Snackbar.LENGTH_LONG)
         snackbar.show()
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/AbstractSearchActivity.kt
@@ -5,7 +5,6 @@ import android.content.Context
 import android.content.Intent
 import android.os.Build
 import android.os.Bundle
-import com.google.android.material.snackbar.Snackbar
 import android.text.TextUtils
 import android.util.Pair
 import android.view.Menu
@@ -20,6 +19,7 @@ import androidx.recyclerview.widget.DefaultItemAnimator
 import androidx.recyclerview.widget.DividerItemDecoration
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
+import com.google.android.material.snackbar.Snackbar
 import com.google.gson.JsonParser
 import de.cineaste.android.R
 import de.cineaste.android.listener.ItemClickListener

--- a/app/src/main/kotlin/de/cineaste/android/activity/MovieDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/MovieDetailActivity.kt
@@ -70,7 +70,7 @@ class MovieDetailActivity : AppCompatActivity() {
                 val movie = currentMovie
                 movie?.let {
                     val tmdbUri = Constants.THE_MOVIE_DB_MOVIES_URI
-                            .replace("<MOVIE_ID>", movie.id.toString())
+                        .replace("<MOVIE_ID>", movie.id.toString())
                     val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(tmdbUri))
                     startActivity(browserIntent)
                 }
@@ -81,13 +81,13 @@ class MovieDetailActivity : AppCompatActivity() {
                     val sharingIntent = Intent(Intent.ACTION_SEND)
                     sharingIntent.type = "text/plain"
                     val shareBodyText = "${movie.title} ${Constants.THE_MOVIE_DB_MOVIES_URI
-                            .replace("<MOVIE_ID>", movie.id.toString())}"
+                        .replace("<MOVIE_ID>", movie.id.toString())}"
                     sharingIntent.putExtra(
-                            Intent.EXTRA_SUBJECT, getString(R.string.share_movie)
+                        Intent.EXTRA_SUBJECT, getString(R.string.share_movie)
                     )
                     sharingIntent.putExtra(Intent.EXTRA_TEXT, shareBodyText)
                     startActivity(
-                            Intent.createChooser(sharingIntent, getString(R.string.share_movie))
+                        Intent.createChooser(sharingIntent, getString(R.string.share_movie))
                     )
                 }
                 return true
@@ -128,8 +128,12 @@ class MovieDetailActivity : AppCompatActivity() {
         if (callback != null) {
             MovieLoader(this).loadLocalizedMovie(movieId, Locale.getDefault(), callback)
             currentMovie?.title?.let { title ->
-                Toast.makeText(this, this.resources.getString(R.string.movieAdd,
-                        title), Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    this, this.resources.getString(
+                        R.string.movieAdd,
+                        title
+                    ), Toast.LENGTH_SHORT
+                ).show()
             }
         }
 
@@ -160,8 +164,12 @@ class MovieDetailActivity : AppCompatActivity() {
         if (callback != null) {
             MovieLoader(this).loadLocalizedMovie(movieId, Locale.getDefault(), callback)
             currentMovie?.let { movie ->
-                Toast.makeText(this, this.resources.getString(R.string.movieAdd,
-                        movie.title), Toast.LENGTH_SHORT).show()
+                Toast.makeText(
+                    this, this.resources.getString(
+                        R.string.movieAdd,
+                        movie.title
+                    ), Toast.LENGTH_SHORT
+                ).show()
             }
         }
 
@@ -288,12 +296,12 @@ class MovieDetailActivity : AppCompatActivity() {
         rating.text = currentMovie.voteAverage.toString()
 
         val posterUri = Constants.POSTER_URI_SMALL
-                .replace("<posterName>", currentMovie.posterPath ?: "/")
-                .replace("<API_KEY>", getString(R.string.movieKey))
+            .replace("<posterName>", currentMovie.posterPath ?: "/")
+            .replace("<API_KEY>", getString(R.string.movieKey))
         Picasso.get()
-                .load(posterUri)
-                .error(R.drawable.placeholder_poster)
-                .into(poster)
+            .load(posterUri)
+            .error(R.drawable.placeholder_poster)
+            .into(poster)
     }
 
     private fun initToolbar() {
@@ -360,17 +368,17 @@ class MovieDetailActivity : AppCompatActivity() {
         val oldMovie = currentMovie
         oldMovie?.let {
             val updatedMovie = Movie(
-                    id = oldMovie.id,
-                    posterPath = movie.posterPath,
-                    title = movie.title,
-                    runtime = movie.runtime,
-                    voteAverage = movie.voteAverage,
-                    voteCount = movie.voteCount,
-                    description = movie.description,
-                    watched = oldMovie.isWatched,
-                    watchedDate = oldMovie.watchedDate,
-                    releaseDate = movie.releaseDate,
-                    listPosition = oldMovie.listPosition
+                id = oldMovie.id,
+                posterPath = movie.posterPath,
+                title = movie.title,
+                runtime = movie.runtime,
+                voteAverage = movie.voteAverage,
+                voteCount = movie.voteCount,
+                description = movie.description,
+                watched = oldMovie.isWatched,
+                watchedDate = oldMovie.watchedDate,
+                releaseDate = movie.releaseDate,
+                listPosition = oldMovie.listPosition
             )
 
             currentMovie = updatedMovie
@@ -409,7 +417,7 @@ class MovieDetailActivity : AppCompatActivity() {
 
     private fun showNetworkError() {
         val snackbar = Snackbar
-                .make(layout, R.string.noInternet, Snackbar.LENGTH_LONG)
+            .make(layout, R.string.noInternet, Snackbar.LENGTH_LONG)
         snackbar.show()
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/activity/MovieDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/MovieDetailActivity.kt
@@ -416,9 +416,9 @@ class MovieDetailActivity : AppCompatActivity() {
     }
 
     private fun showNetworkError() {
-        val snackbar = Snackbar
+        val snackBar = Snackbar
             .make(layout, R.string.noInternet, Snackbar.LENGTH_LONG)
-        snackbar.show()
+        snackBar.show()
     }
 
     private fun convertDate(date: Date?): String {

--- a/app/src/main/kotlin/de/cineaste/android/activity/MovieDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/MovieDetailActivity.kt
@@ -348,19 +348,22 @@ class MovieDetailActivity : AppCompatActivity() {
 
     private fun updateMovie() {
         if (state != R.string.searchState) {
-            MovieLoader(this).loadLocalizedMovie(movieId, Locale.getDefault(), object : MovieCallback {
-                override fun onFailure() {
-                    GlobalScope.launch(Main) { showNetworkError() }
-                }
-
-                override fun onSuccess(movie: Movie) {
-                    GlobalScope.launch(Main) {
-                        assignData(movie)
-                        updateMovieDetails(movie)
-                        movieDbHelper.createOrUpdate(currentMovie ?: movie)
+            MovieLoader(this).loadLocalizedMovie(
+                movieId,
+                Locale.getDefault(),
+                object : MovieCallback {
+                    override fun onFailure() {
+                        GlobalScope.launch(Main) { showNetworkError() }
                     }
-                }
-            })
+
+                    override fun onSuccess(movie: Movie) {
+                        GlobalScope.launch(Main) {
+                            assignData(movie)
+                            updateMovieDetails(movie)
+                            movieDbHelper.createOrUpdate(currentMovie ?: movie)
+                        }
+                    }
+                })
         }
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/activity/MovieDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/MovieDetailActivity.kt
@@ -78,14 +78,14 @@ class MovieDetailActivity : AppCompatActivity() {
 
             R.id.share -> {
                 currentMovie?.let { movie ->
-                    val sharingIntent = Intent(android.content.Intent.ACTION_SEND)
+                    val sharingIntent = Intent(Intent.ACTION_SEND)
                     sharingIntent.type = "text/plain"
                     val shareBodyText = "${movie.title} ${Constants.THE_MOVIE_DB_MOVIES_URI
                             .replace("<MOVIE_ID>", movie.id.toString())}"
                     sharingIntent.putExtra(
-                            android.content.Intent.EXTRA_SUBJECT, getString(R.string.share_movie)
+                            Intent.EXTRA_SUBJECT, getString(R.string.share_movie)
                     )
-                    sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, shareBodyText)
+                    sharingIntent.putExtra(Intent.EXTRA_TEXT, shareBodyText)
                     startActivity(
                             Intent.createChooser(sharingIntent, getString(R.string.share_movie))
                     )

--- a/app/src/main/kotlin/de/cineaste/android/activity/MovieNightActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/MovieNightActivity.kt
@@ -88,9 +88,9 @@ class MovieNightActivity : AppCompatActivity(), UserInputFragment.UserNameListen
 
     private fun initializeTimeout() {
         timeOut = Runnable {
-            val snackbar = Snackbar
+            val snackBar = Snackbar
                 .make(nearbyUserRv, R.string.no_friends_found_try_again, Snackbar.LENGTH_LONG)
-            snackbar.show()
+            snackBar.show()
         }
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/activity/MovieNightActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/MovieNightActivity.kt
@@ -52,8 +52,11 @@ class MovieNightActivity : AppCompatActivity(), UserInputFragment.UserNameListen
     private lateinit var timeOut: Runnable
 
     private val myUUid: String
-        get() = getUUID(getSharedPreferences(
-                applicationContext.packageName, Context.MODE_PRIVATE))
+        get() = getUUID(
+            getSharedPreferences(
+                applicationContext.packageName, Context.MODE_PRIVATE
+            )
+        )
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -86,7 +89,7 @@ class MovieNightActivity : AppCompatActivity(), UserInputFragment.UserNameListen
     private fun initializeTimeout() {
         timeOut = Runnable {
             val snackbar = Snackbar
-                    .make(nearbyUserRv, R.string.no_friends_found_try_again, Snackbar.LENGTH_LONG)
+                .make(nearbyUserRv, R.string.no_friends_found_try_again, Snackbar.LENGTH_LONG)
             snackbar.show()
         }
     }

--- a/app/src/main/kotlin/de/cineaste/android/activity/MovieNightActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/MovieNightActivity.kt
@@ -132,7 +132,7 @@ class MovieNightActivity : AppCompatActivity(), UserInputFragment.UserNameListen
     }
 
     override fun onFinishUserDialog(userName: String) {
-        if (!userName.isEmpty()) {
+        if (userName.isNotEmpty()) {
             currentUser = User(userName)
             currentUser?.let { user ->
                 userDbHelper.createUser(user)

--- a/app/src/main/kotlin/de/cineaste/android/activity/MovieSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/MovieSearchActivity.kt
@@ -75,9 +75,9 @@ class MovieSearchActivity : AbstractSearchActivity(), MovieSearchQueryAdapter.On
     }
 
     private fun movieAddError(movie: Movie, index: Int) {
-        val snackbar = Snackbar
+        val snackBar = Snackbar
             .make(recyclerView, R.string.could_not_add_movie, Snackbar.LENGTH_LONG)
-        snackbar.show()
+        snackBar.show()
         movieQueryAdapter.addMovie(movie, index)
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/activity/MovieSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/MovieSearchActivity.kt
@@ -76,7 +76,7 @@ class MovieSearchActivity : AbstractSearchActivity(), MovieSearchQueryAdapter.On
 
     private fun movieAddError(movie: Movie, index: Int) {
         val snackbar = Snackbar
-                .make(recyclerView, R.string.could_not_add_movie, Snackbar.LENGTH_LONG)
+            .make(recyclerView, R.string.could_not_add_movie, Snackbar.LENGTH_LONG)
         snackbar.show()
         movieQueryAdapter.addMovie(movie, index)
     }

--- a/app/src/main/kotlin/de/cineaste/android/activity/PosterActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/PosterActivity.kt
@@ -66,7 +66,11 @@ class PosterActivity : AppCompatActivity() {
                         .placeholder(placeHolder)
                         .into(poster, object : Callback {
                             override fun onSuccess() {
-                                Snackbar.make(poster, R.string.poster_reloaded, Snackbar.LENGTH_SHORT).show()
+                                Snackbar.make(
+                                    poster,
+                                    R.string.poster_reloaded,
+                                    Snackbar.LENGTH_SHORT
+                                ).show()
                             }
 
                             override fun onError(e: Exception) {

--- a/app/src/main/kotlin/de/cineaste/android/activity/PosterActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/PosterActivity.kt
@@ -30,8 +30,10 @@ class PosterActivity : AppCompatActivity() {
         setTransitionNameIfNecessary()
         poster.setImageResource(R.drawable.placeholder_poster)
         setContentView(poster)
-        window.setFlags(WindowManager.LayoutParams.FLAG_FULLSCREEN,
-                WindowManager.LayoutParams.FLAG_FULLSCREEN)
+        window.setFlags(
+            WindowManager.LayoutParams.FLAG_FULLSCREEN,
+            WindowManager.LayoutParams.FLAG_FULLSCREEN
+        )
 
         displayPoster()
     }
@@ -53,30 +55,30 @@ class PosterActivity : AppCompatActivity() {
 
     private fun displayPoster() {
         Picasso.get()
-                .load(getPosterUrl(Constants.POSTER_URI_SMALL))
-                .error(R.drawable.placeholder_poster)
-                .into(poster, object : Callback {
-                    override fun onSuccess() {
-                        val placeHolder = poster.drawable
-                        setBackgroundColor((placeHolder as BitmapDrawable).bitmap)
-                        Picasso.get()
-                                .load(getPosterUrl(Constants.POSTER_URI_ORIGINAL))
-                                .placeholder(placeHolder)
-                                .into(poster, object : Callback {
-                                    override fun onSuccess() {
-                                        Snackbar.make(poster, R.string.poster_reloaded, Snackbar.LENGTH_SHORT).show()
-                                    }
+            .load(getPosterUrl(Constants.POSTER_URI_SMALL))
+            .error(R.drawable.placeholder_poster)
+            .into(poster, object : Callback {
+                override fun onSuccess() {
+                    val placeHolder = poster.drawable
+                    setBackgroundColor((placeHolder as BitmapDrawable).bitmap)
+                    Picasso.get()
+                        .load(getPosterUrl(Constants.POSTER_URI_ORIGINAL))
+                        .placeholder(placeHolder)
+                        .into(poster, object : Callback {
+                            override fun onSuccess() {
+                                Snackbar.make(poster, R.string.poster_reloaded, Snackbar.LENGTH_SHORT).show()
+                            }
 
-                                    override fun onError(e: Exception) {
-                                        poster.setImageDrawable(placeHolder)
-                                    }
-                                })
-                    }
+                            override fun onError(e: Exception) {
+                                poster.setImageDrawable(placeHolder)
+                            }
+                        })
+                }
 
-                    override fun onError(e: Exception) {
-                        displayPoster()
-                    }
-                })
+                override fun onError(e: Exception) {
+                    displayPoster()
+                }
+            })
     }
 
     private fun setBackgroundColor(moviePoster: Bitmap) {
@@ -91,8 +93,8 @@ class PosterActivity : AppCompatActivity() {
 
     private fun getPosterUrl(postUri: String): String {
         return postUri
-                .replace("<posterName>", posterPath ?: "/")
-                .replace("<API_KEY>", getString(R.string.movieKey))
+            .replace("<posterName>", posterPath ?: "/")
+            .replace("<API_KEY>", getString(R.string.movieKey))
     }
 
     companion object {

--- a/app/src/main/kotlin/de/cineaste/android/activity/ResultActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/ResultActivity.kt
@@ -69,8 +69,9 @@ class ResultActivity : AppCompatActivity(), ResultAdapter.OnMovieSelectListener 
         result.itemAnimator = DefaultItemAnimator()
 
         val resultAdapter = ResultAdapter(
-                results,
-                this)
+            results,
+            this
+        )
         result.adapter = resultAdapter
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/activity/ResultActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/ResultActivity.kt
@@ -95,14 +95,18 @@ class ResultActivity : AppCompatActivity(), ResultAdapter.OnMovieSelectListener 
         val selectedMovie = movieDbHelper.readMovie(selectedMovieId)
 
         if (selectedMovie == null) {
-            MovieLoader(this).loadLocalizedMovie(results[position].id, Locale.getDefault(), (object : MovieCallback {
-                override fun onFailure() {
-                }
+            MovieLoader(this).loadLocalizedMovie(
+                results[position].id,
+                Locale.getDefault(),
+                (object : MovieCallback {
+                    override fun onFailure() {
+                    }
 
-                override fun onSuccess(movie: Movie) {
-                    GlobalScope.launch(Main) { updateMovie(movie) }
-                }
-            }))
+                    override fun onSuccess(movie: Movie) {
+                        GlobalScope.launch(Main) { updateMovie(movie) }
+                    }
+                })
+            )
         } else {
             updateMovie(selectedMovie)
         }

--- a/app/src/main/kotlin/de/cineaste/android/activity/SeasonDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/SeasonDetailActivity.kt
@@ -77,16 +77,16 @@ class SeasonDetailActivity : AppCompatActivity() {
 
             if (posterPath.isNullOrEmpty()) {
                 Picasso.get()
-                        .load(R.drawable.placeholder_poster)
-                        .into(poster)
+                    .load(R.drawable.placeholder_poster)
+                    .into(poster)
             } else {
                 val posterUri = Constants.POSTER_URI_SMALL
-                        .replace("<posterName>", posterPath)
-                        .replace("<API_KEY>", getString(R.string.movieKey))
+                    .replace("<posterName>", posterPath)
+                    .replace("<API_KEY>", getString(R.string.movieKey))
                 Picasso.get()
-                        .load(posterUri)
-                        .error(R.drawable.placeholder_poster)
-                        .into(poster)
+                    .load(posterUri)
+                    .error(R.drawable.placeholder_poster)
+                    .into(poster)
 
                 poster.setOnClickListener {
                     val intent = Intent(this@SeasonDetailActivity, PosterActivity::class.java)

--- a/app/src/main/kotlin/de/cineaste/android/activity/SeasonDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/SeasonDetailActivity.kt
@@ -53,7 +53,11 @@ class SeasonDetailActivity : AppCompatActivity() {
         viewPager.adapter = adapter
         viewPager.currentItem = currentSeasonIndex()
         viewPager.addOnPageChangeListener(object : ViewPager.OnPageChangeListener {
-            override fun onPageScrolled(position: Int, positionOffset: Float, positionOffsetPixels: Int) {
+            override fun onPageScrolled(
+                position: Int,
+                positionOffset: Float,
+                positionOffsetPixels: Int
+            ) {
                 // do nothing
             }
 

--- a/app/src/main/kotlin/de/cineaste/android/activity/SeriesDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/SeriesDetailActivity.kt
@@ -451,8 +451,8 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener,
     }
 
     private fun showNetworkError() {
-        val snackbar = Snackbar
+        val snackBar = Snackbar
             .make(layout, R.string.noInternet, Snackbar.LENGTH_LONG)
-        snackbar.show()
+        snackBar.show()
     }
 }

--- a/app/src/main/kotlin/de/cineaste/android/activity/SeriesDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/SeriesDetailActivity.kt
@@ -34,7 +34,8 @@ import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
-class SeriesDetailActivity : AppCompatActivity(), ItemClickListener, SeriesDetailAdapter.SeriesStateManipulationClickListener, View.OnClickListener {
+class SeriesDetailActivity : AppCompatActivity(), ItemClickListener,
+    SeriesDetailAdapter.SeriesStateManipulationClickListener, View.OnClickListener {
 
     private var state: Int = 0
     private var seriesId: Long = 0
@@ -76,7 +77,7 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener, SeriesDetai
             R.id.more_info -> {
                 currentSeries?.let { series ->
                     val tmdbUri = Constants.THE_MOVIE_DB_SERIES_URI
-                            .replace("<SERIES_ID>", series.id.toString())
+                        .replace("<SERIES_ID>", series.id.toString())
                     val browserIntent = Intent(Intent.ACTION_VIEW, Uri.parse(tmdbUri))
                     startActivity(browserIntent)
                 }
@@ -86,7 +87,10 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener, SeriesDetai
                 currentSeries?.let { series ->
                     val sharingIntent = Intent(Intent.ACTION_SEND)
                     sharingIntent.type = "text/plain"
-                    val shareBodyText = "${series.name} ${Constants.THE_MOVIE_DB_SERIES_URI.replace("<SERIES_ID>", series.id.toString())}"
+                    val shareBodyText = "${series.name} ${Constants.THE_MOVIE_DB_SERIES_URI.replace(
+                        "<SERIES_ID>",
+                        series.id.toString()
+                    )}"
                     sharingIntent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.share_series))
                     sharingIntent.putExtra(Intent.EXTRA_TEXT, shareBodyText)
                     startActivity(Intent.createChooser(sharingIntent, getString(R.string.share_series)))
@@ -136,8 +140,12 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener, SeriesDetai
 
     private fun showAddToast() {
         currentSeries?.let { series ->
-            Toast.makeText(this, this.resources.getString(R.string.movieAdd,
-                    series.name), Toast.LENGTH_SHORT).show()
+            Toast.makeText(
+                this, this.resources.getString(
+                    R.string.movieAdd,
+                    series.name
+                ), Toast.LENGTH_SHORT
+            ).show()
         }
     }
 
@@ -206,8 +214,10 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener, SeriesDetai
 
             startActivity(intent)
         } else {
-            val snackBar = Snackbar.make(layout,
-                    R.string.notAvailableDuringSearch, Snackbar.LENGTH_SHORT)
+            val snackBar = Snackbar.make(
+                layout,
+                R.string.notAvailableDuringSearch, Snackbar.LENGTH_SHORT
+            )
             snackBar.show()
         }
     }
@@ -334,24 +344,24 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener, SeriesDetai
         if (state != R.string.searchState) {
 
             seriesLoader.loadCompleteSeries(seriesId,
-                    object : SeriesCallback {
-                        override fun onFailure() {
-                            GlobalScope.launch(Main) { showNetworkError() }
-                        }
+                object : SeriesCallback {
+                    override fun onFailure() {
+                        GlobalScope.launch(Main) { showNetworkError() }
+                    }
 
-                        override fun onSuccess(series: Series) {
-                            val oldSeries = currentSeries
-                            oldSeries?.let {
-                                series.isWatched = oldSeries.isWatched
-                                series.listPosition = oldSeries.listPosition
-                            }
-                            seriesDbHelper.update(series)
-                            GlobalScope.launch(Main) {
-                                setPoster(series)
-                                adapter.updateSeries(series)
-                            }
+                    override fun onSuccess(series: Series) {
+                        val oldSeries = currentSeries
+                        oldSeries?.let {
+                            series.isWatched = oldSeries.isWatched
+                            series.listPosition = oldSeries.listPosition
+                        }
+                        seriesDbHelper.update(series)
+                        GlobalScope.launch(Main) {
+                            setPoster(series)
+                            adapter.updateSeries(series)
                         }
                     }
+                }
             )
         }
     }
@@ -366,12 +376,12 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener, SeriesDetai
 
     private fun setPoster(series: Series) {
         val posterUri = Constants.POSTER_URI_ORIGINAL
-                .replace("<posterName>", series.backdropPath ?: "/")
-                .replace("<API_KEY>", getString(R.string.movieKey))
+            .replace("<posterName>", series.backdropPath ?: "/")
+            .replace("<API_KEY>", getString(R.string.movieKey))
         Picasso.get()
-                .load(posterUri)
-                .error(R.drawable.placeholder_poster)
-                .into(poster)
+            .load(posterUri)
+            .error(R.drawable.placeholder_poster)
+            .into(poster)
     }
 
     private fun loadRequestedSeries() {
@@ -442,7 +452,7 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener, SeriesDetai
 
     private fun showNetworkError() {
         val snackbar = Snackbar
-                .make(layout, R.string.noInternet, Snackbar.LENGTH_LONG)
+            .make(layout, R.string.noInternet, Snackbar.LENGTH_LONG)
         snackbar.show()
     }
 }

--- a/app/src/main/kotlin/de/cineaste/android/activity/SeriesDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/SeriesDetailActivity.kt
@@ -84,11 +84,11 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener, SeriesDetai
 
             R.id.share -> {
                 currentSeries?.let { series ->
-                    val sharingIntent = Intent(android.content.Intent.ACTION_SEND)
+                    val sharingIntent = Intent(Intent.ACTION_SEND)
                     sharingIntent.type = "text/plain"
                     val shareBodyText = "${series.name} ${Constants.THE_MOVIE_DB_SERIES_URI.replace("<SERIES_ID>", series.id.toString())}"
-                    sharingIntent.putExtra(android.content.Intent.EXTRA_SUBJECT, getString(R.string.share_series))
-                    sharingIntent.putExtra(android.content.Intent.EXTRA_TEXT, shareBodyText)
+                    sharingIntent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.share_series))
+                    sharingIntent.putExtra(Intent.EXTRA_TEXT, shareBodyText)
                     startActivity(Intent.createChooser(sharingIntent, getString(R.string.share_series)))
                 }
                 return true

--- a/app/src/main/kotlin/de/cineaste/android/activity/SeriesDetailActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/SeriesDetailActivity.kt
@@ -93,7 +93,12 @@ class SeriesDetailActivity : AppCompatActivity(), ItemClickListener,
                     )}"
                     sharingIntent.putExtra(Intent.EXTRA_SUBJECT, getString(R.string.share_series))
                     sharingIntent.putExtra(Intent.EXTRA_TEXT, shareBodyText)
-                    startActivity(Intent.createChooser(sharingIntent, getString(R.string.share_series)))
+                    startActivity(
+                        Intent.createChooser(
+                            sharingIntent,
+                            getString(R.string.share_series)
+                        )
+                    )
                 }
                 return true
             }

--- a/app/src/main/kotlin/de/cineaste/android/activity/SeriesSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/SeriesSearchActivity.kt
@@ -22,7 +22,8 @@ import kotlinx.coroutines.Dispatchers.Main
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
-class SeriesSearchActivity : AbstractSearchActivity(), SeriesSearchQueryAdapter.OnSeriesStateChange {
+class SeriesSearchActivity : AbstractSearchActivity(),
+    SeriesSearchQueryAdapter.OnSeriesStateChange {
 
     private lateinit var seriesQueryAdapter: SeriesSearchQueryAdapter
 

--- a/app/src/main/kotlin/de/cineaste/android/activity/SeriesSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/SeriesSearchActivity.kt
@@ -79,7 +79,7 @@ class SeriesSearchActivity : AbstractSearchActivity(), SeriesSearchQueryAdapter.
 
     private fun seriesAddError(series: Series, index: Int) {
         val snackbar = Snackbar
-                .make(recyclerView, R.string.could_not_add_movie, Snackbar.LENGTH_LONG)
+            .make(recyclerView, R.string.could_not_add_movie, Snackbar.LENGTH_LONG)
         snackbar.show()
         seriesQueryAdapter.addSerie(series, index)
     }

--- a/app/src/main/kotlin/de/cineaste/android/activity/SeriesSearchActivity.kt
+++ b/app/src/main/kotlin/de/cineaste/android/activity/SeriesSearchActivity.kt
@@ -71,17 +71,17 @@ class SeriesSearchActivity : AbstractSearchActivity(), SeriesSearchQueryAdapter.
         }
 
         seriesCallback?.let {
-            seriesQueryAdapter.removeSerie(index)
+            seriesQueryAdapter.removeOneSeries(index)
 
             SeriesLoader(this).loadCompleteSeries(series.id, it)
         }
     }
 
     private fun seriesAddError(series: Series, index: Int) {
-        val snackbar = Snackbar
+        val snackBar = Snackbar
             .make(recyclerView, R.string.could_not_add_movie, Snackbar.LENGTH_LONG)
-        snackbar.show()
-        seriesQueryAdapter.addSerie(series, index)
+        snackBar.show()
+        seriesQueryAdapter.addOneSeries(series, index)
     }
 
     override fun initAdapter() {

--- a/app/src/main/kotlin/de/cineaste/android/adapter/BaseListAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/BaseListAdapter.kt
@@ -11,7 +11,12 @@ import android.widget.Filterable
 import de.cineaste.android.fragment.WatchState
 import de.cineaste.android.listener.ItemClickListener
 
-abstract class BaseListAdapter constructor(val context: Context, val displayMessage: DisplayMessage, val listener: ItemClickListener, val state: WatchState) : RecyclerView.Adapter<RecyclerView.ViewHolder>(), Filterable {
+abstract class BaseListAdapter constructor(
+    val context: Context,
+    val displayMessage: DisplayMessage,
+    val listener: ItemClickListener,
+    val state: WatchState
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>(), Filterable {
 
     protected abstract val internalFilter: Filter
     protected abstract val layout: Int
@@ -29,8 +34,8 @@ abstract class BaseListAdapter constructor(val context: Context, val displayMess
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val view = LayoutInflater
-                .from(parent.context)
-                .inflate(layout, parent, false)
+            .from(parent.context)
+            .inflate(layout, parent, false)
         return createViewHolder(view)
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/adapter/ResultAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/ResultAdapter.kt
@@ -44,7 +44,8 @@ class ResultAdapter(
         holder.assignData(results[position], NearbyMessageHandler.size)
     }
 
-    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView), View.OnClickListener {
+    inner class ViewHolder(itemView: View) : RecyclerView.ViewHolder(itemView),
+        View.OnClickListener {
         internal val moviePoster: ImageView = itemView.findViewById(R.id.poster_image_view)
         private val watchedButton: Button = itemView.findViewById(R.id.history_button)
         internal val title: TextView = itemView.findViewById(R.id.title)
@@ -62,7 +63,8 @@ class ResultAdapter(
                 .into(moviePoster)
             watchedButton.setOnClickListener(this)
             title.text = matchingResult.title
-            counter.text = String.format(Locale.getDefault(), "%d/%d", matchingResult.counter, resultCounter)
+            counter.text =
+                String.format(Locale.getDefault(), "%d/%d", matchingResult.counter, resultCounter)
         }
 
         override fun onClick(v: View) {

--- a/app/src/main/kotlin/de/cineaste/android/adapter/ResultAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/ResultAdapter.kt
@@ -48,7 +48,7 @@ class ResultAdapter(
         internal val moviePoster: ImageView = itemView.findViewById(R.id.poster_image_view)
         private val watchedButton: Button = itemView.findViewById(R.id.history_button)
         internal val title: TextView = itemView.findViewById(R.id.title)
-        internal val counter: TextView = itemView.findViewById(R.id.movie_counter_tv)
+        private val counter: TextView = itemView.findViewById(R.id.movie_counter_tv)
 
         fun assignData(matchingResult: MatchingResult, resultCounter: Int) {
             val posterPath = matchingResult.posterPath

--- a/app/src/main/kotlin/de/cineaste/android/adapter/ResultAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/ResultAdapter.kt
@@ -53,13 +53,13 @@ class ResultAdapter(
         fun assignData(matchingResult: MatchingResult, resultCounter: Int) {
             val posterPath = matchingResult.posterPath
             val posterUri = Constants.POSTER_URI_SMALL
-                    .replace("<posterName>", posterPath ?: "/")
-                    .replace("<API_KEY>", context.getString(R.string.movieKey))
+                .replace("<posterName>", posterPath ?: "/")
+                .replace("<API_KEY>", context.getString(R.string.movieKey))
             Picasso.get()
-                    .load(Uri.parse(posterUri))
-                    .resize(222, 334)
-                    .error(R.drawable.placeholder_poster)
-                    .into(moviePoster)
+                .load(Uri.parse(posterUri))
+                .resize(222, 334)
+                .error(R.drawable.placeholder_poster)
+                .into(moviePoster)
             watchedButton.setOnClickListener(this)
             title.text = matchingResult.title
             counter.text = String.format(Locale.getDefault(), "%d/%d", matchingResult.counter, resultCounter)

--- a/app/src/main/kotlin/de/cineaste/android/adapter/movie/MovieListAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/movie/MovieListAdapter.kt
@@ -16,7 +16,12 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.LinkedList
 import java.util.Collections
 
-class MovieListAdapter(displayMessage: DisplayMessage, context: Context, listener: ItemClickListener, state: WatchState) : BaseListAdapter(context, displayMessage, listener, state), OnMovieRemovedListener {
+class MovieListAdapter(
+    displayMessage: DisplayMessage,
+    context: Context,
+    listener: ItemClickListener,
+    state: WatchState
+) : BaseListAdapter(context, displayMessage, listener, state), OnMovieRemovedListener {
 
     private val db: MovieDbHelper = MovieDbHelper.getInstance(context)
     private var dataSet: MutableList<Movie> = ArrayList()
@@ -141,7 +146,10 @@ class MovieListAdapter(displayMessage: DisplayMessage, context: Context, listene
         notifyDataSetChanged()
     }
 
-    inner class FilterMovies internal constructor(private val adapter: MovieListAdapter, private val movieList: List<Movie>) : Filter() {
+    inner class FilterMovies internal constructor(
+        private val adapter: MovieListAdapter,
+        private val movieList: List<Movie>
+    ) : Filter() {
         private val filteredMovieList: MutableList<Movie>
 
         init {

--- a/app/src/main/kotlin/de/cineaste/android/adapter/movie/MovieListAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/movie/MovieListAdapter.kt
@@ -16,7 +16,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.LinkedList
 import java.util.Collections
 
-class MovieListAdapter(displayMessage: BaseListAdapter.DisplayMessage, context: Context, listener: ItemClickListener, state: WatchState) : BaseListAdapter(context, displayMessage, listener, state), OnMovieRemovedListener {
+class MovieListAdapter(displayMessage: DisplayMessage, context: Context, listener: ItemClickListener, state: WatchState) : BaseListAdapter(context, displayMessage, listener, state), OnMovieRemovedListener {
 
     private val db: MovieDbHelper = MovieDbHelper.getInstance(context)
     private var dataSet: MutableList<Movie> = ArrayList()
@@ -148,9 +148,9 @@ class MovieListAdapter(displayMessage: BaseListAdapter.DisplayMessage, context: 
             this.filteredMovieList = ArrayList()
         }
 
-        override fun performFiltering(constraint: CharSequence?): Filter.FilterResults {
+        override fun performFiltering(constraint: CharSequence?): FilterResults {
             filteredMovieList.clear()
-            val results = Filter.FilterResults()
+            val results = FilterResults()
 
             if (constraint == null || constraint.isEmpty()) {
                 filteredMovieList.addAll(movieList)
@@ -170,7 +170,7 @@ class MovieListAdapter(displayMessage: BaseListAdapter.DisplayMessage, context: 
             return results
         }
 
-        override fun publishResults(charSequence: CharSequence, results: Filter.FilterResults) {
+        override fun publishResults(charSequence: CharSequence, results: FilterResults) {
             adapter.filteredDataSet.clear()
 
             adapter.filteredDataSet.addAll(results.values as List<Movie>)

--- a/app/src/main/kotlin/de/cineaste/android/adapter/movie/MovieListAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/movie/MovieListAdapter.kt
@@ -186,5 +186,8 @@ class MovieListAdapter(
         }
     }
 
-    inner class UpdatedMovies internal constructor(internal val prev: Movie, internal val passiveMovie: Movie)
+    inner class UpdatedMovies internal constructor(
+        internal val prev: Movie,
+        internal val passiveMovie: Movie
+    )
 }

--- a/app/src/main/kotlin/de/cineaste/android/adapter/movie/MovieSearchQueryAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/movie/MovieSearchQueryAdapter.kt
@@ -8,7 +8,10 @@ import de.cineaste.android.entity.movie.Movie
 import de.cineaste.android.listener.ItemClickListener
 import de.cineaste.android.viewholder.movie.MovieSearchViewHolder
 
-class MovieSearchQueryAdapter(private val listener: ItemClickListener, private val movieStateChange: OnMovieStateChange) : RecyclerView.Adapter<MovieSearchViewHolder>() {
+class MovieSearchQueryAdapter(
+    private val listener: ItemClickListener,
+    private val movieStateChange: OnMovieStateChange
+) : RecyclerView.Adapter<MovieSearchViewHolder>() {
     private val dataSet = ArrayList<Movie>()
 
     interface OnMovieStateChange {
@@ -36,8 +39,8 @@ class MovieSearchQueryAdapter(private val listener: ItemClickListener, private v
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): MovieSearchViewHolder {
         val v = LayoutInflater
-                .from(parent.context)
-                .inflate(R.layout.card_movie_search, parent, false)
+            .from(parent.context)
+            .inflate(R.layout.card_movie_search, parent, false)
         return MovieSearchViewHolder(v, parent.context, movieStateChange, listener)
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/EpisodeAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/EpisodeAdapter.kt
@@ -7,7 +7,11 @@ import de.cineaste.android.R
 import de.cineaste.android.entity.series.Episode
 import de.cineaste.android.viewholder.series.EpisodeViewHolder
 
-class EpisodeAdapter(episodes: List<Episode>, private val onEpisodeWatchStateChangeListener: EpisodeViewHolder.OnEpisodeWatchStateChangeListener, private val onDescriptionShowToggleListener: EpisodeViewHolder.OnDescriptionShowToggleListener) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
+class EpisodeAdapter(
+    episodes: List<Episode>,
+    private val onEpisodeWatchStateChangeListener: EpisodeViewHolder.OnEpisodeWatchStateChangeListener,
+    private val onDescriptionShowToggleListener: EpisodeViewHolder.OnDescriptionShowToggleListener
+) : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private val episodes: MutableList<Episode> = mutableListOf()
 
@@ -18,10 +22,15 @@ class EpisodeAdapter(episodes: List<Episode>, private val onEpisodeWatchStateCha
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): EpisodeViewHolder {
         val view = LayoutInflater
-                .from(parent.context)
-                .inflate(R.layout.card_episode, parent, false)
+            .from(parent.context)
+            .inflate(R.layout.card_episode, parent, false)
 
-        return EpisodeViewHolder(view, onEpisodeWatchStateChangeListener, onDescriptionShowToggleListener, parent.context)
+        return EpisodeViewHolder(
+            view,
+            onEpisodeWatchStateChangeListener,
+            onDescriptionShowToggleListener,
+            parent.context
+        )
     }
 
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeasonAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeasonAdapter.kt
@@ -10,7 +10,11 @@ import de.cineaste.android.entity.series.Series
 import de.cineaste.android.listener.ItemClickListener
 import de.cineaste.android.viewholder.series.SeasonViewHolder
 
-internal class SeasonAdapter(private val context: Context, private val listener: ItemClickListener, val series: Series?) : RecyclerView.Adapter<SeasonViewHolder>() {
+internal class SeasonAdapter(
+    private val context: Context,
+    private val listener: ItemClickListener,
+    val series: Series?
+) : RecyclerView.Adapter<SeasonViewHolder>() {
 
     private val seasons: MutableList<Season> = mutableListOf()
 
@@ -23,8 +27,8 @@ internal class SeasonAdapter(private val context: Context, private val listener:
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SeasonViewHolder {
         val view = LayoutInflater
-                .from(parent.context)
-                .inflate(R.layout.card_season, parent, false)
+            .from(parent.context)
+            .inflate(R.layout.card_season, parent, false)
 
         return SeasonViewHolder(view, listener, context)
     }

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeasonPagerAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeasonPagerAdapter.kt
@@ -9,7 +9,8 @@ import de.cineaste.android.R
 import de.cineaste.android.entity.series.Series
 import de.cineaste.android.fragment.SeasonDetailFragment
 
-class SeasonPagerAdapter(fm: FragmentManager, private val series: Series, private val resources: Resources) : FragmentStatePagerAdapter(fm) {
+class SeasonPagerAdapter(fm: FragmentManager, private val series: Series, private val resources: Resources) :
+    FragmentStatePagerAdapter(fm) {
 
     override fun getItem(position: Int): Fragment {
         val fragment = SeasonDetailFragment()

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeasonPagerAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeasonPagerAdapter.kt
@@ -9,7 +9,11 @@ import de.cineaste.android.R
 import de.cineaste.android.entity.series.Series
 import de.cineaste.android.fragment.SeasonDetailFragment
 
-class SeasonPagerAdapter(fm: FragmentManager, private val series: Series, private val resources: Resources) :
+class SeasonPagerAdapter(
+    fm: FragmentManager,
+    private val series: Series,
+    private val resources: Resources
+) :
     FragmentStatePagerAdapter(fm) {
 
     override fun getItem(position: Int): Fragment {

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeasonPagerAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeasonPagerAdapter.kt
@@ -32,6 +32,9 @@ class SeasonPagerAdapter(
     }
 
     override fun getPageTitle(position: Int): CharSequence? {
-        return resources.getString(R.string.currentSeason, series.seasons[position].seasonNumber.toString())
+        return resources.getString(
+            R.string.currentSeason,
+            series.seasons[position].seasonNumber.toString()
+        )
     }
 }

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesDetailAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesDetailAdapter.kt
@@ -56,38 +56,38 @@ class SeriesDetailAdapter(
         when (viewType) {
             0 -> {
                 val view = LayoutInflater
-                        .from(parent.context)
-                        .inflate(R.layout.series_detail_triangle, parent, false)
+                    .from(parent.context)
+                    .inflate(R.layout.series_detail_triangle, parent, false)
                 return TriangleViewHolder(view)
             }
             1 -> {
                 val view = LayoutInflater
-                        .from(parent.context)
-                        .inflate(R.layout.series_detail_base, parent, false)
+                    .from(parent.context)
+                    .inflate(R.layout.series_detail_base, parent, false)
                 return BaseViewHolder(view, parent.context, posterClickListener)
             }
             2 -> {
                 val view = LayoutInflater
-                        .from(parent.context)
-                        .inflate(R.layout.series_detail_buttons, parent, false)
+                    .from(parent.context)
+                    .inflate(R.layout.series_detail_buttons, parent, false)
                 return ButtonsViewHolder(view, state, listener)
             }
             3 -> {
                 val view = LayoutInflater
-                        .from(parent.context)
-                        .inflate(R.layout.series_detail_description, parent, false)
+                    .from(parent.context)
+                    .inflate(R.layout.series_detail_description, parent, false)
                 return DescriptionViewHolder(view, parent.context)
             }
             4 -> {
                 val view = LayoutInflater
-                        .from(parent.context)
-                        .inflate(R.layout.series_detail_seasons, parent, false)
+                    .from(parent.context)
+                    .inflate(R.layout.series_detail_seasons, parent, false)
                 return SeasonsListViewHolder(view, parent.context, clickListener)
             }
             else -> {
                 val view = LayoutInflater
-                        .from(parent.context)
-                        .inflate(R.layout.series_detail_base, parent, false)
+                    .from(parent.context)
+                    .inflate(R.layout.series_detail_base, parent, false)
                 return BaseViewHolder(view, parent.context, posterClickListener)
             }
         }
@@ -112,7 +112,7 @@ class SeriesDetailAdapter(
     }
 
     private inner class TriangleViewHolder internal constructor(itemView: View) :
-            RecyclerView.ViewHolder(itemView) {
+        RecyclerView.ViewHolder(itemView) {
         private val rating: TextView = itemView.findViewById(R.id.rating)
 
         internal fun assignData(series: Series) {
@@ -146,9 +146,11 @@ class SeriesDetailAdapter(
 
             episodes.text = resources.getString(R.string.episodes, series.numberOfEpisodes.toString())
             seasons.text = resources.getString(R.string.seasons, series.numberOfSeasons.toString())
-            currentStatus.text = resources.getString(R.string.currentStatus,
-                    series.currentNumberOfSeason.toString(),
-                    series.currentNumberOfEpisode.toString())
+            currentStatus.text = resources.getString(
+                R.string.currentStatus,
+                series.currentNumberOfSeason.toString(),
+                series.currentNumberOfEpisode.toString()
+            )
             if (series.isInProduction) {
                 toBeContinued.visibility = View.VISIBLE
             } else {
@@ -162,13 +164,13 @@ class SeriesDetailAdapter(
         private fun setPoster(series: Series) {
             val posterName = series.posterPath
             val posterUri = Constants.POSTER_URI_SMALL
-                    .replace("<posterName>", posterName ?: "/")
-                    .replace("<API_KEY>", context.getString(R.string.movieKey))
+                .replace("<posterName>", posterName ?: "/")
+                .replace("<API_KEY>", context.getString(R.string.movieKey))
             Picasso.get()
-                    .load(posterUri)
-                    .resize(273, 410)
-                    .error(R.drawable.placeholder_poster)
-                    .into(poster)
+                .load(posterUri)
+                .resize(273, 410)
+                .error(R.drawable.placeholder_poster)
+                .into(poster)
         }
 
         private fun convertDate(date: Date?): String {
@@ -265,14 +267,13 @@ class SeriesDetailAdapter(
         itemView: View,
         private val context: Context,
         private val itemClickListener: ItemClickListener
-    )
-        : RecyclerView.ViewHolder(itemView) {
+    ) : RecyclerView.ViewHolder(itemView) {
         private val recyclerView: RecyclerView = itemView.findViewById(R.id.seasonPoster)
 
         internal fun assignData(series: Series?) {
             recyclerView.layoutManager = StaggeredGridLayoutManager(
-                    2,
-                    StaggeredGridLayoutManager.VERTICAL
+                2,
+                StaggeredGridLayoutManager.VERTICAL
             )
             recyclerView.itemAnimator = DefaultItemAnimator()
             recyclerView.isNestedScrollingEnabled = false

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesDetailAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesDetailAdapter.kt
@@ -144,7 +144,8 @@ class SeriesDetailAdapter(
                 releaseDate.visibility = View.GONE
             }
 
-            episodes.text = resources.getString(R.string.episodes, series.numberOfEpisodes.toString())
+            episodes.text =
+                resources.getString(R.string.episodes, series.numberOfEpisodes.toString())
             seasons.text = resources.getString(R.string.seasons, series.numberOfSeasons.toString())
             currentStatus.text = resources.getString(
                 R.string.currentStatus,

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesListAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesListAdapter.kt
@@ -15,7 +15,7 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.Collections
 import java.util.LinkedList
 
-class SeriesListAdapter(displayMessage: BaseListAdapter.DisplayMessage, context: Context, listener: ItemClickListener, state: WatchState, private val onEpisodeWatchedClickListener: OnEpisodeWatchedClickListener) : BaseListAdapter(context, displayMessage, listener, state) {
+class SeriesListAdapter(displayMessage: DisplayMessage, context: Context, listener: ItemClickListener, state: WatchState, private val onEpisodeWatchedClickListener: OnEpisodeWatchedClickListener) : BaseListAdapter(context, displayMessage, listener, state) {
 
     private val db: SeriesDbHelper
     private var dataSet: MutableList<Series> = mutableListOf()
@@ -179,7 +179,7 @@ class SeriesListAdapter(displayMessage: BaseListAdapter.DisplayMessage, context:
             this.filteredSeriesList = ArrayList()
         }
 
-        override fun performFiltering(constraint: CharSequence?): Filter.FilterResults {
+        override fun performFiltering(constraint: CharSequence?): FilterResults {
             filteredSeriesList.clear()
 
             if (constraint.isNullOrEmpty()) {
@@ -194,14 +194,14 @@ class SeriesListAdapter(displayMessage: BaseListAdapter.DisplayMessage, context:
                 }
             }
 
-            val results = Filter.FilterResults()
+            val results = FilterResults()
             results.values = filteredSeriesList
             results.count = filteredSeriesList.size
 
             return results
         }
 
-        override fun publishResults(charSequence: CharSequence, results: Filter.FilterResults) {
+        override fun publishResults(charSequence: CharSequence, results: FilterResults) {
             adapter.filteredDataSet.clear()
 
             adapter.filteredDataSet.addAll(results.values as List<Series>)

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesListAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesListAdapter.kt
@@ -15,7 +15,13 @@ import java.util.concurrent.LinkedBlockingQueue
 import java.util.Collections
 import java.util.LinkedList
 
-class SeriesListAdapter(displayMessage: DisplayMessage, context: Context, listener: ItemClickListener, state: WatchState, private val onEpisodeWatchedClickListener: OnEpisodeWatchedClickListener) : BaseListAdapter(context, displayMessage, listener, state) {
+class SeriesListAdapter(
+    displayMessage: DisplayMessage,
+    context: Context,
+    listener: ItemClickListener,
+    state: WatchState,
+    private val onEpisodeWatchedClickListener: OnEpisodeWatchedClickListener
+) : BaseListAdapter(context, displayMessage, listener, state) {
 
     private val db: SeriesDbHelper
     private var dataSet: MutableList<Series> = mutableListOf()
@@ -172,7 +178,10 @@ class SeriesListAdapter(displayMessage: DisplayMessage, context: Context, listen
         notifyDataSetChanged()
     }
 
-    inner class FilerSeries internal constructor(private val adapter: SeriesListAdapter, private val seriesList: List<Series>) : Filter() {
+    inner class FilerSeries internal constructor(
+        private val adapter: SeriesListAdapter,
+        private val seriesList: List<Series>
+    ) : Filter() {
         private val filteredSeriesList: MutableList<Series>
 
         init {

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesListAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesListAdapter.kt
@@ -73,13 +73,23 @@ class SeriesListAdapter(
         }
     }
 
-    fun addDeletedItemToHistoryAgain(series: Series, position: Int, prevSeason: Int, prevEpisode: Int) {
+    fun addDeletedItemToHistoryAgain(
+        series: Series,
+        position: Int,
+        prevSeason: Int,
+        prevEpisode: Int
+    ) {
         db.addToHistory(series)
         db.moveBackToHistory(series, prevSeason, prevEpisode)
         addSeriesToList(series, position)
     }
 
-    fun addDeletedItemToWatchListAgain(series: Series, position: Int, prevSeason: Int, prevEpisode: Int) {
+    fun addDeletedItemToWatchListAgain(
+        series: Series,
+        position: Int,
+        prevSeason: Int,
+        prevEpisode: Int
+    ) {
         db.addToWatchList(series)
         db.moveBackToWatchList(series, prevSeason, prevEpisode)
         addSeriesToList(series, position)
@@ -218,5 +228,8 @@ class SeriesListAdapter(
         }
     }
 
-    inner class UpdatedSeries internal constructor(internal val prev: Series, internal val passiveSeries: Series)
+    inner class UpdatedSeries internal constructor(
+        internal val prev: Series,
+        internal val passiveSeries: Series
+    )
 }

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesSearchQueryAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesSearchQueryAdapter.kt
@@ -24,11 +24,11 @@ class SeriesSearchQueryAdapter(
         notifyDataSetChanged()
     }
 
-    fun addSerie(series: Series, index: Int) {
+    fun addOneSeries(series: Series, index: Int) {
         dataSet.add(index, series)
     }
 
-    fun removeSerie(index: Int) {
+    fun removeOneSeries(index: Int) {
         dataSet.removeAt(index)
         notifyItemRemoved(index)
     }

--- a/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesSearchQueryAdapter.kt
+++ b/app/src/main/kotlin/de/cineaste/android/adapter/series/SeriesSearchQueryAdapter.kt
@@ -8,7 +8,10 @@ import de.cineaste.android.entity.series.Series
 import de.cineaste.android.listener.ItemClickListener
 import de.cineaste.android.viewholder.series.SeriesSearchViewHolder
 
-class SeriesSearchQueryAdapter(private val listener: ItemClickListener, private val seriesStateChange: OnSeriesStateChange) : RecyclerView.Adapter<SeriesSearchViewHolder>() {
+class SeriesSearchQueryAdapter(
+    private val listener: ItemClickListener,
+    private val seriesStateChange: OnSeriesStateChange
+) : RecyclerView.Adapter<SeriesSearchViewHolder>() {
     private val dataSet = ArrayList<Series>()
 
     interface OnSeriesStateChange {
@@ -32,8 +35,8 @@ class SeriesSearchQueryAdapter(private val listener: ItemClickListener, private 
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): SeriesSearchViewHolder {
         val view = LayoutInflater
-                .from(parent.context)
-                .inflate(R.layout.card_series_search, parent, false)
+            .from(parent.context)
+            .inflate(R.layout.card_series_search, parent, false)
         return SeriesSearchViewHolder(view, listener, parent.context, seriesStateChange)
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/behavior/ScrollAwareFABBehavior.kt
+++ b/app/src/main/kotlin/de/cineaste/android/behavior/ScrollAwareFABBehavior.kt
@@ -11,7 +11,8 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 @Suppress("unused")
-class ScrollAwareFABBehavior(@Suppress("UNUSED_PARAMETER")context: Context, @Suppress("UNUSED_PARAMETER")attrs: AttributeSet) : FloatingActionButton.Behavior() {
+class ScrollAwareFABBehavior(@Suppress("UNUSED_PARAMETER") context: Context, @Suppress("UNUSED_PARAMETER") attrs: AttributeSet) :
+    FloatingActionButton.Behavior() {
 
     override fun onStartNestedScroll(
         coordinatorLayout: CoordinatorLayout,
@@ -23,12 +24,13 @@ class ScrollAwareFABBehavior(@Suppress("UNUSED_PARAMETER")context: Context, @Sup
     ): Boolean {
 
         return nestedScrollAxes == ViewCompat.SCROLL_AXIS_VERTICAL || super.onStartNestedScroll(
-                coordinatorLayout,
-                child,
-                directTargetChild,
-                target,
-                nestedScrollAxes,
-                type)
+            coordinatorLayout,
+            child,
+            directTargetChild,
+            target,
+            nestedScrollAxes,
+            type
+        )
     }
 
     override fun onNestedScroll(
@@ -42,14 +44,15 @@ class ScrollAwareFABBehavior(@Suppress("UNUSED_PARAMETER")context: Context, @Sup
         type: Int
     ) {
         super.onNestedScroll(
-                coordinatorLayout,
-                child,
-                target,
-                dxConsumed,
-                dyConsumed,
-                dxUnconsumed,
-                dyUnconsumed,
-                type)
+            coordinatorLayout,
+            child,
+            target,
+            dxConsumed,
+            dyConsumed,
+            dxUnconsumed,
+            dyUnconsumed,
+            type
+        )
 
         if (dyConsumed > 0 && child.visibility == View.VISIBLE) {
             child.hide()

--- a/app/src/main/kotlin/de/cineaste/android/behavior/ScrollAwareFABBehavior.kt
+++ b/app/src/main/kotlin/de/cineaste/android/behavior/ScrollAwareFABBehavior.kt
@@ -11,7 +11,10 @@ import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.launch
 
 @Suppress("unused")
-class ScrollAwareFABBehavior(@Suppress("UNUSED_PARAMETER") context: Context, @Suppress("UNUSED_PARAMETER") attrs: AttributeSet) :
+class ScrollAwareFABBehavior(
+    @Suppress("UNUSED_PARAMETER") context: Context,
+    @Suppress("UNUSED_PARAMETER") attrs: AttributeSet
+) :
     FloatingActionButton.Behavior() {
 
     override fun onStartNestedScroll(

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/BaseSnackBar.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/BaseSnackBar.kt
@@ -3,7 +3,10 @@ package de.cineaste.android.controllFlow
 import androidx.recyclerview.widget.LinearLayoutManager
 import android.view.View
 
-abstract class BaseSnackBar protected constructor(protected val linearLayoutManager: LinearLayoutManager, protected val view: View) {
+abstract class BaseSnackBar protected constructor(
+    protected val linearLayoutManager: LinearLayoutManager,
+    protected val view: View
+) {
 
     abstract fun getSnackBarLeftSwipe(position: Int)
     abstract fun getSnackBarRightSwipe(position: Int, message: Int)

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/TouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/TouchHelperCallback.kt
@@ -11,7 +11,11 @@ import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.ItemTouchHelper
 import de.cineaste.android.R
 
-abstract class TouchHelperCallback protected constructor(private val resources: Resources, protected val linearLayoutManager: LinearLayoutManager, protected val recyclerView: RecyclerView) : ItemTouchHelper.Callback() {
+abstract class TouchHelperCallback protected constructor(
+    private val resources: Resources,
+    protected val linearLayoutManager: LinearLayoutManager,
+    protected val recyclerView: RecyclerView
+) : ItemTouchHelper.Callback() {
 
     protected abstract val snackBar: BaseSnackBar
 
@@ -44,7 +48,15 @@ abstract class TouchHelperCallback protected constructor(private val resources: 
         }
     }
 
-    override fun onChildDraw(c: Canvas, recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, dX: Float, dY: Float, actionState: Int, isCurrentlyActive: Boolean) {
+    override fun onChildDraw(
+        c: Canvas,
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        dX: Float,
+        dY: Float,
+        actionState: Int,
+        isCurrentlyActive: Boolean
+    ) {
 
         if (actionState == ItemTouchHelper.ACTION_STATE_SWIPE) {
 

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/TouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/TouchHelperCallback.kt
@@ -31,7 +31,10 @@ abstract class TouchHelperCallback protected constructor(
         return true
     }
 
-    override fun getMovementFlags(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder): Int {
+    override fun getMovementFlags(
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder
+    ): Int {
 
         val dragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN
         val swipeFlags = ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/TouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/TouchHelperCallback.kt
@@ -31,7 +31,7 @@ abstract class TouchHelperCallback protected constructor(private val resources: 
 
         val dragFlags = ItemTouchHelper.UP or ItemTouchHelper.DOWN
         val swipeFlags = ItemTouchHelper.LEFT or ItemTouchHelper.RIGHT
-        return ItemTouchHelper.Callback.makeMovementFlags(dragFlags, swipeFlags)
+        return makeMovementFlags(dragFlags, swipeFlags)
     }
 
     override fun onSwiped(viewHolder: RecyclerView.ViewHolder, direction: Int) {

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/BaseMovieTouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/BaseMovieTouchHelperCallback.kt
@@ -15,9 +15,13 @@ abstract class BaseMovieTouchHelperCallback(
     recyclerView: RecyclerView,
     resources: Resources
 ) :
-        TouchHelperCallback(resources, linearLayoutManager, recyclerView) {
+    TouchHelperCallback(resources, linearLayoutManager, recyclerView) {
 
-    override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
+    override fun onMove(
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        target: RecyclerView.ViewHolder
+    ): Boolean {
         movieListAdapter.onItemMove(viewHolder.adapterPosition, target.adapterPosition)
         return true
     }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/HistoryListMovieTouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/HistoryListMovieTouchHelperCallback.kt
@@ -8,7 +8,12 @@ import de.cineaste.android.R
 import de.cineaste.android.adapter.movie.MovieListAdapter
 import de.cineaste.android.controllFlow.BaseSnackBar
 
-class HistoryListMovieTouchHelperCallback(linearLayoutManager: LinearLayoutManager, movieListAdapter: MovieListAdapter, recyclerView: RecyclerView, resources: Resources) : BaseMovieTouchHelperCallback(linearLayoutManager, movieListAdapter, recyclerView, resources) {
+class HistoryListMovieTouchHelperCallback(
+    linearLayoutManager: LinearLayoutManager,
+    movieListAdapter: MovieListAdapter,
+    recyclerView: RecyclerView,
+    resources: Resources
+) : BaseMovieTouchHelperCallback(linearLayoutManager, movieListAdapter, recyclerView, resources) {
 
     override val icon: Int
         get() = R.drawable.ic_add_to_watchlist_white

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/MovieSnackBarHistory.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/MovieSnackBarHistory.kt
@@ -18,53 +18,49 @@ class MovieSnackBarHistory internal constructor(
         val movieToBeDeleted = adapter.getItem(position)
         adapter.removeItem(position)
 
-        val mySnackbar = Snackbar.make(
+        val mySnackBar = Snackbar.make(
             view,
             R.string.movie_deleted, Snackbar.LENGTH_LONG
         )
-        mySnackbar.setAction(R.string.undo) {
+        mySnackBar.setAction(R.string.undo) {
             // do nothing
         }
-        mySnackbar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+        mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                when (event) {
-                    Snackbar.Callback.DISMISS_EVENT_ACTION -> {
-                        adapter.restoreDeletedItem(movieToBeDeleted, position)
-                        val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
-                        if (first >= position) {
-                            linearLayoutManager.scrollToPosition(position)
-                        }
+                if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
+                    adapter.restoreDeletedItem(movieToBeDeleted, position)
+                    val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
+                    if (first >= position) {
+                        linearLayoutManager.scrollToPosition(position)
                     }
                 }
             }
         })
-        mySnackbar.show()
+        mySnackBar.show()
     }
 
     override fun getSnackBarRightSwipe(position: Int, message: Int) {
         val movieToBeUpdated = adapter.getItem(position)
         adapter.toggleItemOnList(movieToBeUpdated)
 
-        val mySnackbar = Snackbar.make(
+        val mySnackBar = Snackbar.make(
             view,
             message, Snackbar.LENGTH_LONG
         )
-        mySnackbar.setAction(R.string.undo) {
+        mySnackBar.setAction(R.string.undo) {
             // do nothing
         }
-        mySnackbar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+        mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                when (event) {
-                    Snackbar.Callback.DISMISS_EVENT_ACTION -> {
-                        adapter.restoreToggleItemOnList(movieToBeUpdated, position)
-                        val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
-                        if (first >= position) {
-                            linearLayoutManager.scrollToPosition(position)
-                        }
+                if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
+                    adapter.restoreToggleItemOnList(movieToBeUpdated, position)
+                    val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
+                    if (first >= position) {
+                        linearLayoutManager.scrollToPosition(position)
                     }
                 }
             }
         })
-        mySnackbar.show()
+        mySnackBar.show()
     }
 }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/MovieSnackBarHistory.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/MovieSnackBarHistory.kt
@@ -8,14 +8,20 @@ import de.cineaste.android.R
 import de.cineaste.android.adapter.movie.MovieListAdapter
 import de.cineaste.android.controllFlow.BaseSnackBar
 
-class MovieSnackBarHistory internal constructor(linearLayoutManager: LinearLayoutManager, private val adapter: MovieListAdapter, view: View) : BaseSnackBar(linearLayoutManager, view) {
+class MovieSnackBarHistory internal constructor(
+    linearLayoutManager: LinearLayoutManager,
+    private val adapter: MovieListAdapter,
+    view: View
+) : BaseSnackBar(linearLayoutManager, view) {
 
     override fun getSnackBarLeftSwipe(position: Int) {
         val movieToBeDeleted = adapter.getItem(position)
         adapter.removeItem(position)
 
-        val mySnackbar = Snackbar.make(view,
-                R.string.movie_deleted, Snackbar.LENGTH_LONG)
+        val mySnackbar = Snackbar.make(
+            view,
+            R.string.movie_deleted, Snackbar.LENGTH_LONG
+        )
         mySnackbar.setAction(R.string.undo) {
             // do nothing
         }
@@ -39,8 +45,10 @@ class MovieSnackBarHistory internal constructor(linearLayoutManager: LinearLayou
         val movieToBeUpdated = adapter.getItem(position)
         adapter.toggleItemOnList(movieToBeUpdated)
 
-        val mySnackbar = Snackbar.make(view,
-                message, Snackbar.LENGTH_LONG)
+        val mySnackbar = Snackbar.make(
+            view,
+            message, Snackbar.LENGTH_LONG
+        )
         mySnackbar.setAction(R.string.undo) {
             // do nothing
         }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/MovieSnackBarWatchList.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/MovieSnackBarWatchList.kt
@@ -18,53 +18,49 @@ class MovieSnackBarWatchList internal constructor(
         val movieToBeDeleted = adapter.getItem(position)
         adapter.removeItem(position)
 
-        val mySnackbar = Snackbar.make(
+        val mySnackBar = Snackbar.make(
             view,
             R.string.movie_deleted, Snackbar.LENGTH_LONG
         )
-        mySnackbar.setAction(R.string.undo) {
+        mySnackBar.setAction(R.string.undo) {
             // do nothing
         }
-        mySnackbar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+        mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                when (event) {
-                    Snackbar.Callback.DISMISS_EVENT_ACTION -> {
-                        adapter.restoreDeletedItem(movieToBeDeleted, position)
-                        val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
-                        if (first >= position) {
-                            linearLayoutManager.scrollToPosition(position)
-                        }
+                if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
+                    adapter.restoreDeletedItem(movieToBeDeleted, position)
+                    val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
+                    if (first >= position) {
+                        linearLayoutManager.scrollToPosition(position)
                     }
                 }
             }
         })
-        mySnackbar.show()
+        mySnackBar.show()
     }
 
     override fun getSnackBarRightSwipe(position: Int, message: Int) {
         val movieToBeUpdated = adapter.getItem(position)
         adapter.toggleItemOnList(movieToBeUpdated)
 
-        val mySnackbar = Snackbar.make(
+        val mySnackBar = Snackbar.make(
             view,
             message, Snackbar.LENGTH_LONG
         )
-        mySnackbar.setAction(R.string.undo) {
+        mySnackBar.setAction(R.string.undo) {
             // do nothing
         }
-        mySnackbar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+        mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                when (event) {
-                    Snackbar.Callback.DISMISS_EVENT_ACTION -> {
-                        adapter.restoreToggleItemOnList(movieToBeUpdated, position)
-                        val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
-                        if (first >= position) {
-                            linearLayoutManager.scrollToPosition(position)
-                        }
+                if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
+                    adapter.restoreToggleItemOnList(movieToBeUpdated, position)
+                    val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
+                    if (first >= position) {
+                        linearLayoutManager.scrollToPosition(position)
                     }
                 }
             }
         })
-        mySnackbar.show()
+        mySnackBar.show()
     }
 }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/MovieSnackBarWatchList.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/MovieSnackBarWatchList.kt
@@ -8,14 +8,20 @@ import de.cineaste.android.R
 import de.cineaste.android.adapter.movie.MovieListAdapter
 import de.cineaste.android.controllFlow.BaseSnackBar
 
-class MovieSnackBarWatchList internal constructor(linearLayoutManager: LinearLayoutManager, private val adapter: MovieListAdapter, view: View) : BaseSnackBar(linearLayoutManager, view) {
+class MovieSnackBarWatchList internal constructor(
+    linearLayoutManager: LinearLayoutManager,
+    private val adapter: MovieListAdapter,
+    view: View
+) : BaseSnackBar(linearLayoutManager, view) {
 
     override fun getSnackBarLeftSwipe(position: Int) {
         val movieToBeDeleted = adapter.getItem(position)
         adapter.removeItem(position)
 
-        val mySnackbar = Snackbar.make(view,
-                R.string.movie_deleted, Snackbar.LENGTH_LONG)
+        val mySnackbar = Snackbar.make(
+            view,
+            R.string.movie_deleted, Snackbar.LENGTH_LONG
+        )
         mySnackbar.setAction(R.string.undo) {
             // do nothing
         }
@@ -39,8 +45,10 @@ class MovieSnackBarWatchList internal constructor(linearLayoutManager: LinearLay
         val movieToBeUpdated = adapter.getItem(position)
         adapter.toggleItemOnList(movieToBeUpdated)
 
-        val mySnackbar = Snackbar.make(view,
-                message, Snackbar.LENGTH_LONG)
+        val mySnackbar = Snackbar.make(
+            view,
+            message, Snackbar.LENGTH_LONG
+        )
         mySnackbar.setAction(R.string.undo) {
             // do nothing
         }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/WatchlistMovieTouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/movie/WatchlistMovieTouchHelperCallback.kt
@@ -8,7 +8,12 @@ import de.cineaste.android.R
 import de.cineaste.android.adapter.movie.MovieListAdapter
 import de.cineaste.android.controllFlow.BaseSnackBar
 
-class WatchlistMovieTouchHelperCallback(linearLayoutManager: LinearLayoutManager, movieListAdapter: MovieListAdapter, recyclerView: RecyclerView, resources: Resources) : BaseMovieTouchHelperCallback(linearLayoutManager, movieListAdapter, recyclerView, resources) {
+class WatchlistMovieTouchHelperCallback(
+    linearLayoutManager: LinearLayoutManager,
+    movieListAdapter: MovieListAdapter,
+    recyclerView: RecyclerView,
+    resources: Resources
+) : BaseMovieTouchHelperCallback(linearLayoutManager, movieListAdapter, recyclerView, resources) {
 
     override val snackBar: BaseSnackBar
         get() = MovieSnackBarWatchList(linearLayoutManager, movieListAdapter, recyclerView)

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/BaseSeriesTouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/BaseSeriesTouchHelperCallback.kt
@@ -9,9 +9,18 @@ import de.cineaste.android.adapter.series.SeriesListAdapter
 import de.cineaste.android.controllFlow.TouchHelperCallback
 import de.cineaste.android.viewholder.series.SeriesViewHolder
 
-abstract class BaseSeriesTouchHelperCallback(resources: Resources, linearLayoutManager: LinearLayoutManager, recyclerView: RecyclerView, val seriesListAdapter: SeriesListAdapter) : TouchHelperCallback(resources, linearLayoutManager, recyclerView) {
+abstract class BaseSeriesTouchHelperCallback(
+    resources: Resources,
+    linearLayoutManager: LinearLayoutManager,
+    recyclerView: RecyclerView,
+    val seriesListAdapter: SeriesListAdapter
+) : TouchHelperCallback(resources, linearLayoutManager, recyclerView) {
 
-    override fun onMove(recyclerView: RecyclerView, viewHolder: RecyclerView.ViewHolder, target: RecyclerView.ViewHolder): Boolean {
+    override fun onMove(
+        recyclerView: RecyclerView,
+        viewHolder: RecyclerView.ViewHolder,
+        target: RecyclerView.ViewHolder
+    ): Boolean {
         seriesListAdapter.onItemMove(viewHolder.adapterPosition, target.adapterPosition)
         return true
     }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/HistoryListSeriesTouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/HistoryListSeriesTouchHelperCallback.kt
@@ -8,7 +8,12 @@ import de.cineaste.android.R
 import de.cineaste.android.adapter.series.SeriesListAdapter
 import de.cineaste.android.controllFlow.BaseSnackBar
 
-class HistoryListSeriesTouchHelperCallback(resources: Resources, linearLayoutManager: LinearLayoutManager, recyclerView: RecyclerView, seriesListAdapter: SeriesListAdapter) : BaseSeriesTouchHelperCallback(resources, linearLayoutManager, recyclerView, seriesListAdapter) {
+class HistoryListSeriesTouchHelperCallback(
+    resources: Resources,
+    linearLayoutManager: LinearLayoutManager,
+    recyclerView: RecyclerView,
+    seriesListAdapter: SeriesListAdapter
+) : BaseSeriesTouchHelperCallback(resources, linearLayoutManager, recyclerView, seriesListAdapter) {
 
     override val icon: Int
         get() = R.drawable.ic_add_to_watchlist_white

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarHistory.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarHistory.kt
@@ -31,7 +31,12 @@ class SeriesSnackBarHistory internal constructor(
         mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
                 if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
-                    adapter.addDeletedItemToHistoryAgain(seriesToBeDeleted, position, currentSeason, currentEpisode)
+                    adapter.addDeletedItemToHistoryAgain(
+                        seriesToBeDeleted,
+                        position,
+                        currentSeason,
+                        currentEpisode
+                    )
                     val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
                     if (first >= position) {
                         linearLayoutManager.scrollToPosition(position)
@@ -56,7 +61,12 @@ class SeriesSnackBarHistory internal constructor(
         mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
                 if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
-                    adapter.moveBackToHistory(seriesToBeUpdated, position, currentSeason, currentEpisode)
+                    adapter.moveBackToHistory(
+                        seriesToBeUpdated,
+                        position,
+                        currentSeason,
+                        currentEpisode
+                    )
                     val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
                     if (first >= position) {
                         linearLayoutManager.scrollToPosition(position)

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarHistory.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarHistory.kt
@@ -30,13 +30,11 @@ class SeriesSnackBarHistory internal constructor(
         }
         mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                when (event) {
-                    Snackbar.Callback.DISMISS_EVENT_ACTION -> {
-                        adapter.addDeletedItemToHistoryAgain(seriesToBeDeleted, position, currentSeason, currentEpisode)
-                        val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
-                        if (first >= position) {
-                            linearLayoutManager.scrollToPosition(position)
-                        }
+                if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
+                    adapter.addDeletedItemToHistoryAgain(seriesToBeDeleted, position, currentSeason, currentEpisode)
+                    val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
+                    if (first >= position) {
+                        linearLayoutManager.scrollToPosition(position)
                     }
                 }
             }
@@ -57,13 +55,11 @@ class SeriesSnackBarHistory internal constructor(
         }
         mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                when (event) {
-                    Snackbar.Callback.DISMISS_EVENT_ACTION -> {
-                        adapter.moveBackToHistory(seriesToBeUpdated, position, currentSeason, currentEpisode)
-                        val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
-                        if (first >= position) {
-                            linearLayoutManager.scrollToPosition(position)
-                        }
+                if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
+                    adapter.moveBackToHistory(seriesToBeUpdated, position, currentSeason, currentEpisode)
+                    val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
+                    if (first >= position) {
+                        linearLayoutManager.scrollToPosition(position)
                     }
                 }
             }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarHistory.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarHistory.kt
@@ -8,7 +8,11 @@ import de.cineaste.android.R
 import de.cineaste.android.adapter.series.SeriesListAdapter
 import de.cineaste.android.controllFlow.BaseSnackBar
 
-class SeriesSnackBarHistory internal constructor(linearLayoutManager: LinearLayoutManager, view: View, private val adapter: SeriesListAdapter) : BaseSnackBar(linearLayoutManager, view) {
+class SeriesSnackBarHistory internal constructor(
+    linearLayoutManager: LinearLayoutManager,
+    view: View,
+    private val adapter: SeriesListAdapter
+) : BaseSnackBar(linearLayoutManager, view) {
 
     override fun getSnackBarLeftSwipe(position: Int) {
         val seriesToBeDeleted = adapter.getItem(position)
@@ -17,8 +21,10 @@ class SeriesSnackBarHistory internal constructor(linearLayoutManager: LinearLayo
         val currentSeason = seriesToBeDeleted.currentNumberOfSeason
         val currentEpisode = seriesToBeDeleted.currentNumberOfEpisode
 
-        val mySnackBar = Snackbar.make(view,
-                R.string.series_deleted, Snackbar.LENGTH_LONG)
+        val mySnackBar = Snackbar.make(
+            view,
+            R.string.series_deleted, Snackbar.LENGTH_LONG
+        )
         mySnackBar.setAction(R.string.undo) {
             // do nothing
         }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
@@ -25,32 +25,30 @@ class SeriesSnackBarWatchList internal constructor(
         val currentSeason = seriesToBeDeleted.currentNumberOfSeason
         val currentEpisode = seriesToBeDeleted.currentNumberOfEpisode
 
-        val mySnackbar = Snackbar.make(
+        val mySnackBar = Snackbar.make(
             view,
             R.string.series_deleted, Snackbar.LENGTH_LONG
         )
-        mySnackbar.setAction(R.string.undo) {
+        mySnackBar.setAction(R.string.undo) {
             // do nothing
         }
-        mySnackbar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+        mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                when (event) {
-                    Snackbar.Callback.DISMISS_EVENT_ACTION -> {
-                        adapter.addDeletedItemToWatchListAgain(
-                            seriesToBeDeleted,
-                            position,
-                            currentSeason,
-                            currentEpisode
-                        )
-                        val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
-                        if (first >= position) {
-                            linearLayoutManager.scrollToPosition(position)
-                        }
+                if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
+                    adapter.addDeletedItemToWatchListAgain(
+                        seriesToBeDeleted,
+                        position,
+                        currentSeason,
+                        currentEpisode
+                    )
+                    val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
+                    if (first >= position) {
+                        linearLayoutManager.scrollToPosition(position)
                     }
                 }
             }
         })
-        mySnackbar.show()
+        mySnackBar.show()
     }
 
     override fun getSnackBarRightSwipe(position: Int, message: Int) {
@@ -88,26 +86,24 @@ class SeriesSnackBarWatchList internal constructor(
         val currentEpisode = seriesToBeUpdated.currentNumberOfEpisode
 
         adapter.moveToHistory(seriesToBeUpdated)
-        val mySnackbar = Snackbar.make(
+        val mySnackBar = Snackbar.make(
             view,
             message, Snackbar.LENGTH_LONG
         )
-        mySnackbar.setAction(R.string.undo) {
+        mySnackBar.setAction(R.string.undo) {
             // do nothing
         }
-        mySnackbar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
+        mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
-                when (event) {
-                    Snackbar.Callback.DISMISS_EVENT_ACTION -> {
-                        adapter.moveBackToWatchList(seriesToBeUpdated, position, currentSeason, currentEpisode)
-                        val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
-                        if (first >= position) {
-                            linearLayoutManager.scrollToPosition(position)
-                        }
+                if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
+                    adapter.moveBackToWatchList(seriesToBeUpdated, position, currentSeason, currentEpisode)
+                    val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
+                    if (first >= position) {
+                        linearLayoutManager.scrollToPosition(position)
                     }
                 }
             }
         })
-        mySnackbar.show()
+        mySnackBar.show()
     }
 }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
@@ -80,7 +80,11 @@ class SeriesSnackBarWatchList internal constructor(
     }
 
     // todo  reset to current season end episode after dismiss update current status
-    private fun updateSeriesAndCreateSnackBar(position: Int, message: Int, seriesToBeUpdated: Series) {
+    private fun updateSeriesAndCreateSnackBar(
+        position: Int,
+        message: Int,
+        seriesToBeUpdated: Series
+    ) {
 
         val currentSeason = seriesToBeUpdated.currentNumberOfSeason
         val currentEpisode = seriesToBeUpdated.currentNumberOfEpisode

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
@@ -71,7 +71,12 @@ class SeriesSnackBarWatchList internal constructor(
                     series
                 )
             }
-            alertBuilder.setNegativeButton(R.string.cancel) { _, _ -> adapter.addSeriesToList(series, position) }
+            alertBuilder.setNegativeButton(R.string.cancel) { _, _ ->
+                adapter.addSeriesToList(
+                    series,
+                    position
+                )
+            }
 
             alertBuilder.create().show()
         } else {
@@ -100,7 +105,12 @@ class SeriesSnackBarWatchList internal constructor(
         mySnackBar.addCallback(object : BaseTransientBottomBar.BaseCallback<Snackbar>() {
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
                 if (event == Snackbar.Callback.DISMISS_EVENT_ACTION) {
-                    adapter.moveBackToWatchList(seriesToBeUpdated, position, currentSeason, currentEpisode)
+                    adapter.moveBackToWatchList(
+                        seriesToBeUpdated,
+                        position,
+                        currentSeason,
+                        currentEpisode
+                    )
                     val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
                     if (first >= position) {
                         linearLayoutManager.scrollToPosition(position)

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
@@ -65,7 +65,7 @@ class SeriesSnackBarWatchList internal constructor(
             alertBuilder.setTitle(context.getString(R.string.seriesSeenHeadline, series.name))
             alertBuilder.setMessage(R.string.seriesStillInProduction)
             alertBuilder.setPositiveButton(R.string.ok) { _, _ ->
-                updateSeriesAndCreateSnackbar(
+                updateSeriesAndCreateSnackBar(
                     position,
                     message,
                     series
@@ -75,12 +75,12 @@ class SeriesSnackBarWatchList internal constructor(
 
             alertBuilder.create().show()
         } else {
-            updateSeriesAndCreateSnackbar(position, message, series)
+            updateSeriesAndCreateSnackBar(position, message, series)
         }
     }
 
     // todo  reset to current season end episode after dismiss update current status
-    private fun updateSeriesAndCreateSnackbar(position: Int, message: Int, seriesToBeUpdated: Series) {
+    private fun updateSeriesAndCreateSnackBar(position: Int, message: Int, seriesToBeUpdated: Series) {
 
         val currentSeason = seriesToBeUpdated.currentNumberOfSeason
         val currentEpisode = seriesToBeUpdated.currentNumberOfEpisode

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/SeriesSnackBarWatchList.kt
@@ -11,7 +11,12 @@ import de.cineaste.android.adapter.series.SeriesListAdapter
 import de.cineaste.android.controllFlow.BaseSnackBar
 import de.cineaste.android.entity.series.Series
 
-class SeriesSnackBarWatchList internal constructor(linearLayoutManager: LinearLayoutManager, view: View, private val adapter: SeriesListAdapter, private val context: Context) : BaseSnackBar(linearLayoutManager, view) {
+class SeriesSnackBarWatchList internal constructor(
+    linearLayoutManager: LinearLayoutManager,
+    view: View,
+    private val adapter: SeriesListAdapter,
+    private val context: Context
+) : BaseSnackBar(linearLayoutManager, view) {
 
     override fun getSnackBarLeftSwipe(position: Int) {
         val seriesToBeDeleted = adapter.getItem(position)
@@ -20,8 +25,10 @@ class SeriesSnackBarWatchList internal constructor(linearLayoutManager: LinearLa
         val currentSeason = seriesToBeDeleted.currentNumberOfSeason
         val currentEpisode = seriesToBeDeleted.currentNumberOfEpisode
 
-        val mySnackbar = Snackbar.make(view,
-                R.string.series_deleted, Snackbar.LENGTH_LONG)
+        val mySnackbar = Snackbar.make(
+            view,
+            R.string.series_deleted, Snackbar.LENGTH_LONG
+        )
         mySnackbar.setAction(R.string.undo) {
             // do nothing
         }
@@ -29,7 +36,12 @@ class SeriesSnackBarWatchList internal constructor(linearLayoutManager: LinearLa
             override fun onDismissed(transientBottomBar: Snackbar?, event: Int) {
                 when (event) {
                     Snackbar.Callback.DISMISS_EVENT_ACTION -> {
-                        adapter.addDeletedItemToWatchListAgain(seriesToBeDeleted, position, currentSeason, currentEpisode)
+                        adapter.addDeletedItemToWatchListAgain(
+                            seriesToBeDeleted,
+                            position,
+                            currentSeason,
+                            currentEpisode
+                        )
                         val first = linearLayoutManager.findFirstCompletelyVisibleItemPosition()
                         if (first >= position) {
                             linearLayoutManager.scrollToPosition(position)
@@ -54,7 +66,13 @@ class SeriesSnackBarWatchList internal constructor(linearLayoutManager: LinearLa
             val alertBuilder = AlertDialog.Builder(context)
             alertBuilder.setTitle(context.getString(R.string.seriesSeenHeadline, series.name))
             alertBuilder.setMessage(R.string.seriesStillInProduction)
-            alertBuilder.setPositiveButton(R.string.ok) { _, _ -> updateSeriesAndCreateSnackbar(position, message, series) }
+            alertBuilder.setPositiveButton(R.string.ok) { _, _ ->
+                updateSeriesAndCreateSnackbar(
+                    position,
+                    message,
+                    series
+                )
+            }
             alertBuilder.setNegativeButton(R.string.cancel) { _, _ -> adapter.addSeriesToList(series, position) }
 
             alertBuilder.create().show()
@@ -70,8 +88,10 @@ class SeriesSnackBarWatchList internal constructor(linearLayoutManager: LinearLa
         val currentEpisode = seriesToBeUpdated.currentNumberOfEpisode
 
         adapter.moveToHistory(seriesToBeUpdated)
-        val mySnackbar = Snackbar.make(view,
-                message, Snackbar.LENGTH_LONG)
+        val mySnackbar = Snackbar.make(
+            view,
+            message, Snackbar.LENGTH_LONG
+        )
         mySnackbar.setAction(R.string.undo) {
             // do nothing
         }

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/WatchlistSeriesTouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/WatchlistSeriesTouchHelperCallback.kt
@@ -18,7 +18,12 @@ class WatchlistSeriesTouchHelperCallback(
 ) : BaseSeriesTouchHelperCallback(resources, linearLayoutManager, recyclerView, seriesListAdapter) {
 
     override val snackBar: BaseSnackBar
-        get() = SeriesSnackBarWatchList(linearLayoutManager, recyclerView, seriesListAdapter, context)
+        get() = SeriesSnackBarWatchList(
+            linearLayoutManager,
+            recyclerView,
+            seriesListAdapter,
+            context
+        )
 
     override val icon: Int
         get() = R.drawable.ic_add_to_history_white

--- a/app/src/main/kotlin/de/cineaste/android/controllFlow/series/WatchlistSeriesTouchHelperCallback.kt
+++ b/app/src/main/kotlin/de/cineaste/android/controllFlow/series/WatchlistSeriesTouchHelperCallback.kt
@@ -9,7 +9,13 @@ import de.cineaste.android.R
 import de.cineaste.android.adapter.series.SeriesListAdapter
 import de.cineaste.android.controllFlow.BaseSnackBar
 
-class WatchlistSeriesTouchHelperCallback(resources: Resources, linearLayoutManager: LinearLayoutManager, recyclerView: RecyclerView, seriesListAdapter: SeriesListAdapter, private val context: Context) : BaseSeriesTouchHelperCallback(resources, linearLayoutManager, recyclerView, seriesListAdapter) {
+class WatchlistSeriesTouchHelperCallback(
+    resources: Resources,
+    linearLayoutManager: LinearLayoutManager,
+    recyclerView: RecyclerView,
+    seriesListAdapter: SeriesListAdapter,
+    private val context: Context
+) : BaseSeriesTouchHelperCallback(resources, linearLayoutManager, recyclerView, seriesListAdapter) {
 
     override val snackBar: BaseSnackBar
         get() = SeriesSnackBarWatchList(linearLayoutManager, recyclerView, seriesListAdapter, context)

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/BaseDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/BaseDao.kt
@@ -117,56 +117,61 @@ abstract class BaseDao protected constructor(context: Context) :
         private const val INTEGER_TYPE = " INTEGER"
         private const val REAL_TYPE = " REAL"
         private const val COMMA_SEP = ","
-        private const val SQL_CREATE_USER_ENTRIES = "CREATE TABLE IF NOT EXISTS " + UserEntry.TABLE_NAME + " (" +
-                UserEntry.ID + INTEGER_TYPE + " PRIMARY KEY AUTOINCREMENT" + COMMA_SEP +
-                UserEntry.COLUMN_USER_NAME + TEXT_TYPE +
-                " )"
-        private const val SQL_CREATE_MOVIE_ENTRIES = "CREATE TABLE IF NOT EXISTS " + MovieEntry.TABLE_NAME + " (" +
-                MovieEntry.ID + INTEGER_TYPE + " PRIMARY KEY" + COMMA_SEP +
-                MovieEntry.COLUMN_MOVIE_TITLE + TEXT_TYPE + COMMA_SEP +
-                MovieEntry.COlUMN_POSTER_PATH + TEXT_TYPE + COMMA_SEP +
-                MovieEntry.COLUMN_RUNTIME + INTEGER_TYPE + COMMA_SEP +
-                MovieEntry.COLUMN_VOTE_AVERAGE + REAL_TYPE + COMMA_SEP +
-                MovieEntry.COLUMN_VOTE_COUNT + INTEGER_TYPE + COMMA_SEP +
-                MovieEntry.COLUMN_MOVIE_DESCRIPTION + TEXT_TYPE + COMMA_SEP +
-                MovieEntry.COLUMN_MOVIE_WATCHED + INTEGER_TYPE + COMMA_SEP +
-                MovieEntry.COLUMN_MOVIE_WATCHED_DATE + INTEGER_TYPE + COMMA_SEP +
-                MovieEntry.COLUMN_MOVIE_RELEASE_DATE + TEXT_TYPE + COMMA_SEP +
-                MovieEntry.COLUMN_MOVIE_LIST_POSITION + INTEGER_TYPE +
-                " )"
-        private const val SQL_CREATE_SERIES_ENTRIES = "CREATE TABLE IF NOT EXISTS " + SeriesEntry.TABLE_NAME + " (" +
-                SeriesEntry.ID + INTEGER_TYPE + " PRIMARY KEY" + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_NAME + TEXT_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE + REAL_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_VOTE_COUNT + INTEGER_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_DESCRIPTION + TEXT_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_RELEASE_DATE + TEXT_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_IN_PRODUCTION + INTEGER_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES + INTEGER_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS + INTEGER_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_POSTER_PATH + TEXT_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_BACKDROP_PATH + TEXT_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_SERIES_WATCHED + INTEGER_TYPE + COMMA_SEP +
-                SeriesEntry.COLUMN_SERIES_LIST_POSITION + INTEGER_TYPE +
-                " )"
-        private const val SQL_CREATE_SEASON_ENTRIES = "CREATE TABLE IF NOT EXISTS " + SeasonEntry.TABLE_NAME + " (" +
-                SeasonEntry.ID + INTEGER_TYPE + " PRIMARY KEY" + COMMA_SEP +
-                SeasonEntry.COLUMN_SEASON_RELEASE_DATE + TEXT_TYPE + COMMA_SEP +
-                SeasonEntry.COLUMN_SEASON_EPISODE_COUNT + INTEGER_TYPE + COMMA_SEP +
-                SeasonEntry.COLUMN_SEASON_POSTER_PATH + TEXT_TYPE + COMMA_SEP +
-                SeasonEntry.COLUMN_SEASON_SEASON_NUMBER + INTEGER_TYPE + COMMA_SEP +
-                SeasonEntry.COLUMN_SEASON_WATCHED + INTEGER_TYPE + COMMA_SEP +
-                SeasonEntry.COLUMN_SEASON_SERIES_ID + INTEGER_TYPE + " )"
+        private const val SQL_CREATE_USER_ENTRIES =
+            "CREATE TABLE IF NOT EXISTS " + UserEntry.TABLE_NAME + " (" +
+                    UserEntry.ID + INTEGER_TYPE + " PRIMARY KEY AUTOINCREMENT" + COMMA_SEP +
+                    UserEntry.COLUMN_USER_NAME + TEXT_TYPE +
+                    " )"
+        private const val SQL_CREATE_MOVIE_ENTRIES =
+            "CREATE TABLE IF NOT EXISTS " + MovieEntry.TABLE_NAME + " (" +
+                    MovieEntry.ID + INTEGER_TYPE + " PRIMARY KEY" + COMMA_SEP +
+                    MovieEntry.COLUMN_MOVIE_TITLE + TEXT_TYPE + COMMA_SEP +
+                    MovieEntry.COlUMN_POSTER_PATH + TEXT_TYPE + COMMA_SEP +
+                    MovieEntry.COLUMN_RUNTIME + INTEGER_TYPE + COMMA_SEP +
+                    MovieEntry.COLUMN_VOTE_AVERAGE + REAL_TYPE + COMMA_SEP +
+                    MovieEntry.COLUMN_VOTE_COUNT + INTEGER_TYPE + COMMA_SEP +
+                    MovieEntry.COLUMN_MOVIE_DESCRIPTION + TEXT_TYPE + COMMA_SEP +
+                    MovieEntry.COLUMN_MOVIE_WATCHED + INTEGER_TYPE + COMMA_SEP +
+                    MovieEntry.COLUMN_MOVIE_WATCHED_DATE + INTEGER_TYPE + COMMA_SEP +
+                    MovieEntry.COLUMN_MOVIE_RELEASE_DATE + TEXT_TYPE + COMMA_SEP +
+                    MovieEntry.COLUMN_MOVIE_LIST_POSITION + INTEGER_TYPE +
+                    " )"
+        private const val SQL_CREATE_SERIES_ENTRIES =
+            "CREATE TABLE IF NOT EXISTS " + SeriesEntry.TABLE_NAME + " (" +
+                    SeriesEntry.ID + INTEGER_TYPE + " PRIMARY KEY" + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_NAME + TEXT_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE + REAL_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_VOTE_COUNT + INTEGER_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_DESCRIPTION + TEXT_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_RELEASE_DATE + TEXT_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_IN_PRODUCTION + INTEGER_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES + INTEGER_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS + INTEGER_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_POSTER_PATH + TEXT_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_BACKDROP_PATH + TEXT_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_SERIES_WATCHED + INTEGER_TYPE + COMMA_SEP +
+                    SeriesEntry.COLUMN_SERIES_LIST_POSITION + INTEGER_TYPE +
+                    " )"
+        private const val SQL_CREATE_SEASON_ENTRIES =
+            "CREATE TABLE IF NOT EXISTS " + SeasonEntry.TABLE_NAME + " (" +
+                    SeasonEntry.ID + INTEGER_TYPE + " PRIMARY KEY" + COMMA_SEP +
+                    SeasonEntry.COLUMN_SEASON_RELEASE_DATE + TEXT_TYPE + COMMA_SEP +
+                    SeasonEntry.COLUMN_SEASON_EPISODE_COUNT + INTEGER_TYPE + COMMA_SEP +
+                    SeasonEntry.COLUMN_SEASON_POSTER_PATH + TEXT_TYPE + COMMA_SEP +
+                    SeasonEntry.COLUMN_SEASON_SEASON_NUMBER + INTEGER_TYPE + COMMA_SEP +
+                    SeasonEntry.COLUMN_SEASON_WATCHED + INTEGER_TYPE + COMMA_SEP +
+                    SeasonEntry.COLUMN_SEASON_SERIES_ID + INTEGER_TYPE + " )"
 
-        private const val SQL_CREATE_EPISODE_ENTRIES = "CREATE TABLE IF NOT EXISTS " + EpisodeEntry.TABLE_NAME + " (" +
-                EpisodeEntry.ID + INTEGER_TYPE + " PRIMARY KEY" + COMMA_SEP +
-                EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER + INTEGER_TYPE + COMMA_SEP +
-                EpisodeEntry.COLUMN_EPISODE_NAME + TEXT_TYPE + COMMA_SEP +
-                EpisodeEntry.COLUMN_EPISODE_DESCRIPTION + TEXT_TYPE + COMMA_SEP +
-                EpisodeEntry.COLUMN_EPISODE_SERIES_ID + INTEGER_TYPE + COMMA_SEP +
-                EpisodeEntry.COLUMN_EPISODE_SEASON_ID + INTEGER_TYPE + COMMA_SEP +
-                EpisodeEntry.COLUMN_EPISODE_WATCHED + INTEGER_TYPE +
-                " )"
+        private const val SQL_CREATE_EPISODE_ENTRIES =
+            "CREATE TABLE IF NOT EXISTS " + EpisodeEntry.TABLE_NAME + " (" +
+                    EpisodeEntry.ID + INTEGER_TYPE + " PRIMARY KEY" + COMMA_SEP +
+                    EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER + INTEGER_TYPE + COMMA_SEP +
+                    EpisodeEntry.COLUMN_EPISODE_NAME + TEXT_TYPE + COMMA_SEP +
+                    EpisodeEntry.COLUMN_EPISODE_DESCRIPTION + TEXT_TYPE + COMMA_SEP +
+                    EpisodeEntry.COLUMN_EPISODE_SERIES_ID + INTEGER_TYPE + COMMA_SEP +
+                    EpisodeEntry.COLUMN_EPISODE_SEASON_ID + INTEGER_TYPE + COMMA_SEP +
+                    EpisodeEntry.COLUMN_EPISODE_WATCHED + INTEGER_TYPE +
+                    " )"
 
         private const val DATABASE_VERSION = Constants.DATABASE_VERSION
         private const val DATABASE_NAME = Constants.DATABASE_NAME

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/BaseDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/BaseDao.kt
@@ -10,7 +10,8 @@ import java.util.Locale
 
 import de.cineaste.android.util.Constants
 
-abstract class BaseDao protected constructor(context: Context) : SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
+abstract class BaseDao protected constructor(context: Context) :
+    SQLiteOpenHelper(context, DATABASE_NAME, null, DATABASE_VERSION) {
 
     protected val readDb: SQLiteDatabase = readableDatabase
     protected val writeDb: SQLiteDatabase = writableDatabase

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/EpisodeDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/EpisodeDao.kt
@@ -65,12 +65,16 @@ class EpisodeDao private constructor(context: Context) : BaseDao(context) {
                 currentEpisode.id = c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.ID))
                 currentEpisode.episodeNumber =
                     c.getInt(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER))
-                currentEpisode.name = c.getString(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_NAME))
+                currentEpisode.name =
+                    c.getString(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_NAME))
                 currentEpisode.description =
                     c.getString(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_DESCRIPTION))
-                currentEpisode.seriesId = c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_SERIES_ID))
-                currentEpisode.seasonId = c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_SEASON_ID))
-                currentEpisode.isWatched = c.getInt(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_WATCHED)) > 0
+                currentEpisode.seriesId =
+                    c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_SERIES_ID))
+                currentEpisode.seasonId =
+                    c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_SEASON_ID))
+                currentEpisode.isWatched =
+                    c.getInt(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_WATCHED)) > 0
 
                 episodes.add(currentEpisode)
             } while (c.moveToNext())

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/EpisodeDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/EpisodeDao.kt
@@ -19,8 +19,10 @@ class EpisodeDao private constructor(context: Context) : BaseDao(context) {
         values.put(EpisodeEntry.COLUMN_EPISODE_SEASON_ID, episode.seasonId)
         values.put(EpisodeEntry.COLUMN_EPISODE_WATCHED, if (episode.isWatched) 1 else 0)
 
-        writeDb.insert(EpisodeEntry.TABLE_NAME,
-                null, values)
+        writeDb.insert(
+            EpisodeEntry.TABLE_NAME,
+            null, values
+        )
     }
 
     fun create(episode: Episode, seriesId: Long, seasonId: Long) {
@@ -39,22 +41,33 @@ class EpisodeDao private constructor(context: Context) : BaseDao(context) {
     fun read(selection: String, selectionArgs: Array<String>): List<Episode> {
         val episodes = ArrayList<Episode>()
 
-        val projection = arrayOf(EpisodeEntry.ID, EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER, EpisodeEntry.COLUMN_EPISODE_NAME, EpisodeEntry.COLUMN_EPISODE_DESCRIPTION, EpisodeEntry.COLUMN_EPISODE_SERIES_ID, EpisodeEntry.COLUMN_EPISODE_SEASON_ID, EpisodeEntry.COLUMN_EPISODE_WATCHED)
+        val projection = arrayOf(
+            EpisodeEntry.ID,
+            EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER,
+            EpisodeEntry.COLUMN_EPISODE_NAME,
+            EpisodeEntry.COLUMN_EPISODE_DESCRIPTION,
+            EpisodeEntry.COLUMN_EPISODE_SERIES_ID,
+            EpisodeEntry.COLUMN_EPISODE_SEASON_ID,
+            EpisodeEntry.COLUMN_EPISODE_WATCHED
+        )
 
         val c = readDb.query(
-                EpisodeEntry.TABLE_NAME,
-                projection,
-                selection,
-                selectionArgs, null, null,
-                EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER + " ASC", null)
+            EpisodeEntry.TABLE_NAME,
+            projection,
+            selection,
+            selectionArgs, null, null,
+            EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER + " ASC", null
+        )
 
         if (c.moveToFirst()) {
             do {
                 val currentEpisode = Episode()
                 currentEpisode.id = c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.ID))
-                currentEpisode.episodeNumber = c.getInt(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER))
+                currentEpisode.episodeNumber =
+                    c.getInt(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER))
                 currentEpisode.name = c.getString(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_NAME))
-                currentEpisode.description = c.getString(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_DESCRIPTION))
+                currentEpisode.description =
+                    c.getString(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_DESCRIPTION))
                 currentEpisode.seriesId = c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_SERIES_ID))
                 currentEpisode.seasonId = c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_SEASON_ID))
                 currentEpisode.isWatched = c.getInt(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_WATCHED)) > 0
@@ -83,7 +96,11 @@ class EpisodeDao private constructor(context: Context) : BaseDao(context) {
     }
 
     fun deleteBySeriesId(seriesId: Long) {
-        writeDb.delete(EpisodeEntry.TABLE_NAME, EpisodeEntry.COLUMN_EPISODE_SERIES_ID + " = ?", arrayOf(seriesId.toString() + ""))
+        writeDb.delete(
+            EpisodeEntry.TABLE_NAME,
+            EpisodeEntry.COLUMN_EPISODE_SERIES_ID + " = ?",
+            arrayOf(seriesId.toString() + "")
+        )
     }
 
     companion object {

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/EpisodeDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/EpisodeDao.kt
@@ -12,52 +12,52 @@ class EpisodeDao private constructor(context: Context) : BaseDao(context) {
 
     fun create(episode: Episode) {
         val values = ContentValues()
-        values.put(BaseDao.EpisodeEntry.ID, episode.id)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER, episode.episodeNumber)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_NAME, episode.name)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_DESCRIPTION, episode.description)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_SEASON_ID, episode.seasonId)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_WATCHED, if (episode.isWatched) 1 else 0)
+        values.put(EpisodeEntry.ID, episode.id)
+        values.put(EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER, episode.episodeNumber)
+        values.put(EpisodeEntry.COLUMN_EPISODE_NAME, episode.name)
+        values.put(EpisodeEntry.COLUMN_EPISODE_DESCRIPTION, episode.description)
+        values.put(EpisodeEntry.COLUMN_EPISODE_SEASON_ID, episode.seasonId)
+        values.put(EpisodeEntry.COLUMN_EPISODE_WATCHED, if (episode.isWatched) 1 else 0)
 
-        writeDb.insert(BaseDao.EpisodeEntry.TABLE_NAME,
+        writeDb.insert(EpisodeEntry.TABLE_NAME,
                 null, values)
     }
 
     fun create(episode: Episode, seriesId: Long, seasonId: Long) {
         val values = ContentValues()
-        values.put(BaseDao.EpisodeEntry.ID, episode.id)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER, episode.episodeNumber)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_NAME, episode.name)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_DESCRIPTION, episode.description)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_SERIES_ID, seriesId)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_SEASON_ID, seasonId)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_WATCHED, if (episode.isWatched) 1 else 0)
+        values.put(EpisodeEntry.ID, episode.id)
+        values.put(EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER, episode.episodeNumber)
+        values.put(EpisodeEntry.COLUMN_EPISODE_NAME, episode.name)
+        values.put(EpisodeEntry.COLUMN_EPISODE_DESCRIPTION, episode.description)
+        values.put(EpisodeEntry.COLUMN_EPISODE_SERIES_ID, seriesId)
+        values.put(EpisodeEntry.COLUMN_EPISODE_SEASON_ID, seasonId)
+        values.put(EpisodeEntry.COLUMN_EPISODE_WATCHED, if (episode.isWatched) 1 else 0)
 
-        writeDb.insert(BaseDao.EpisodeEntry.TABLE_NAME, null, values)
+        writeDb.insert(EpisodeEntry.TABLE_NAME, null, values)
     }
 
     fun read(selection: String, selectionArgs: Array<String>): List<Episode> {
         val episodes = ArrayList<Episode>()
 
-        val projection = arrayOf(BaseDao.EpisodeEntry.ID, BaseDao.EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER, BaseDao.EpisodeEntry.COLUMN_EPISODE_NAME, BaseDao.EpisodeEntry.COLUMN_EPISODE_DESCRIPTION, BaseDao.EpisodeEntry.COLUMN_EPISODE_SERIES_ID, BaseDao.EpisodeEntry.COLUMN_EPISODE_SEASON_ID, BaseDao.EpisodeEntry.COLUMN_EPISODE_WATCHED)
+        val projection = arrayOf(EpisodeEntry.ID, EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER, EpisodeEntry.COLUMN_EPISODE_NAME, EpisodeEntry.COLUMN_EPISODE_DESCRIPTION, EpisodeEntry.COLUMN_EPISODE_SERIES_ID, EpisodeEntry.COLUMN_EPISODE_SEASON_ID, EpisodeEntry.COLUMN_EPISODE_WATCHED)
 
         val c = readDb.query(
-                BaseDao.EpisodeEntry.TABLE_NAME,
+                EpisodeEntry.TABLE_NAME,
                 projection,
                 selection,
                 selectionArgs, null, null,
-                BaseDao.EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER + " ASC", null)
+                EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER + " ASC", null)
 
         if (c.moveToFirst()) {
             do {
                 val currentEpisode = Episode()
-                currentEpisode.id = c.getLong(c.getColumnIndexOrThrow(BaseDao.EpisodeEntry.ID))
-                currentEpisode.episodeNumber = c.getInt(c.getColumnIndexOrThrow(BaseDao.EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER))
-                currentEpisode.name = c.getString(c.getColumnIndexOrThrow(BaseDao.EpisodeEntry.COLUMN_EPISODE_NAME))
-                currentEpisode.description = c.getString(c.getColumnIndexOrThrow(BaseDao.EpisodeEntry.COLUMN_EPISODE_DESCRIPTION))
-                currentEpisode.seriesId = c.getLong(c.getColumnIndexOrThrow(BaseDao.EpisodeEntry.COLUMN_EPISODE_SERIES_ID))
-                currentEpisode.seasonId = c.getLong(c.getColumnIndexOrThrow(BaseDao.EpisodeEntry.COLUMN_EPISODE_SEASON_ID))
-                currentEpisode.isWatched = c.getInt(c.getColumnIndexOrThrow(BaseDao.EpisodeEntry.COLUMN_EPISODE_WATCHED)) > 0
+                currentEpisode.id = c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.ID))
+                currentEpisode.episodeNumber = c.getInt(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER))
+                currentEpisode.name = c.getString(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_NAME))
+                currentEpisode.description = c.getString(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_DESCRIPTION))
+                currentEpisode.seriesId = c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_SERIES_ID))
+                currentEpisode.seasonId = c.getLong(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_SEASON_ID))
+                currentEpisode.isWatched = c.getInt(c.getColumnIndexOrThrow(EpisodeEntry.COLUMN_EPISODE_WATCHED)) > 0
 
                 episodes.add(currentEpisode)
             } while (c.moveToNext())
@@ -68,22 +68,22 @@ class EpisodeDao private constructor(context: Context) : BaseDao(context) {
 
     fun update(episode: Episode) {
         val values = ContentValues()
-        values.put(BaseDao.EpisodeEntry.ID, episode.id)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER, episode.episodeNumber)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_NAME, episode.name)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_DESCRIPTION, episode.description)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_SERIES_ID, episode.seriesId)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_SEASON_ID, episode.seasonId)
-        values.put(BaseDao.EpisodeEntry.COLUMN_EPISODE_WATCHED, if (episode.isWatched) 1 else 0)
+        values.put(EpisodeEntry.ID, episode.id)
+        values.put(EpisodeEntry.COLUMN_EPISODE_EPISODE_NUMBER, episode.episodeNumber)
+        values.put(EpisodeEntry.COLUMN_EPISODE_NAME, episode.name)
+        values.put(EpisodeEntry.COLUMN_EPISODE_DESCRIPTION, episode.description)
+        values.put(EpisodeEntry.COLUMN_EPISODE_SERIES_ID, episode.seriesId)
+        values.put(EpisodeEntry.COLUMN_EPISODE_SEASON_ID, episode.seasonId)
+        values.put(EpisodeEntry.COLUMN_EPISODE_WATCHED, if (episode.isWatched) 1 else 0)
 
-        val selection = BaseDao.EpisodeEntry.ID + " LIKE ?"
+        val selection = EpisodeEntry.ID + " LIKE ?"
         val selectionArgs = arrayOf(episode.id.toString())
 
-        writeDb.update(BaseDao.EpisodeEntry.TABLE_NAME, values, selection, selectionArgs)
+        writeDb.update(EpisodeEntry.TABLE_NAME, values, selection, selectionArgs)
     }
 
     fun deleteBySeriesId(seriesId: Long) {
-        writeDb.delete(BaseDao.EpisodeEntry.TABLE_NAME, BaseDao.EpisodeEntry.COLUMN_EPISODE_SERIES_ID + " = ?", arrayOf(seriesId.toString() + ""))
+        writeDb.delete(EpisodeEntry.TABLE_NAME, EpisodeEntry.COLUMN_EPISODE_SERIES_ID + " = ?", arrayOf(seriesId.toString() + ""))
     }
 
     companion object {

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/MovieDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/MovieDao.kt
@@ -39,14 +39,27 @@ class MovieDao private constructor(context: Context) : BaseDao(context) {
     fun read(selection: String?, selectionArgs: Array<String>?, orderBy: String?): List<Movie> {
         val movies = ArrayList<Movie>()
 
-        val projection = arrayOf(MovieEntry.ID, MovieEntry.COLUMN_MOVIE_TITLE, MovieEntry.COlUMN_POSTER_PATH, MovieEntry.COLUMN_RUNTIME, MovieEntry.COLUMN_VOTE_AVERAGE, MovieEntry.COLUMN_VOTE_COUNT, MovieEntry.COLUMN_MOVIE_DESCRIPTION, MovieEntry.COLUMN_MOVIE_WATCHED, MovieEntry.COLUMN_MOVIE_WATCHED_DATE, MovieEntry.COLUMN_MOVIE_RELEASE_DATE, MovieEntry.COLUMN_MOVIE_LIST_POSITION)
+        val projection = arrayOf(
+            MovieEntry.ID,
+            MovieEntry.COLUMN_MOVIE_TITLE,
+            MovieEntry.COlUMN_POSTER_PATH,
+            MovieEntry.COLUMN_RUNTIME,
+            MovieEntry.COLUMN_VOTE_AVERAGE,
+            MovieEntry.COLUMN_VOTE_COUNT,
+            MovieEntry.COLUMN_MOVIE_DESCRIPTION,
+            MovieEntry.COLUMN_MOVIE_WATCHED,
+            MovieEntry.COLUMN_MOVIE_WATCHED_DATE,
+            MovieEntry.COLUMN_MOVIE_RELEASE_DATE,
+            MovieEntry.COLUMN_MOVIE_LIST_POSITION
+        )
 
         val c = readDb.query(
-                MovieEntry.TABLE_NAME,
-                projection,
-                selection,
-                selectionArgs, null, null,
-                orderBy, null)
+            MovieEntry.TABLE_NAME,
+            projection,
+            selection,
+            selectionArgs, null, null,
+            orderBy, null
+        )
 
         if (c.moveToFirst()) {
             do {
@@ -59,10 +72,12 @@ class MovieDao private constructor(context: Context) : BaseDao(context) {
                 currentMovie.voteCount = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_VOTE_COUNT))
                 currentMovie.description = c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_DESCRIPTION))
                 currentMovie.isWatched = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_WATCHED)) > 0
-                currentMovie.watchedDate = Date(c.getLong(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_WATCHED_DATE)))
+                currentMovie.watchedDate =
+                    Date(c.getLong(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_WATCHED_DATE)))
 
                 try {
-                    currentMovie.releaseDate = sdf.parse(c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_RELEASE_DATE)))
+                    currentMovie.releaseDate =
+                        sdf.parse(c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_RELEASE_DATE)))
                 } catch (ex: Exception) {
                     currentMovie.releaseDate = null
                 }
@@ -94,10 +109,11 @@ class MovieDao private constructor(context: Context) : BaseDao(context) {
         val selectionArg = if (watchState) "1" else "0"
 
         val c = writeDb.query(
-                MovieEntry.TABLE_NAME,
-                projection,
-                selection,
-                arrayOf(selectionArg), null, null, null)
+            MovieEntry.TABLE_NAME,
+            projection,
+            selection,
+            arrayOf(selectionArg), null, null, null
+        )
         if (c.moveToFirst()) {
             do {
                 highestPos = c.getInt(c.getColumnIndex("POS"))

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/MovieDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/MovieDao.kt
@@ -13,36 +13,36 @@ class MovieDao private constructor(context: Context) : BaseDao(context) {
 
     fun create(movie: Movie) {
         val values = ContentValues()
-        values.put(BaseDao.MovieEntry.ID, movie.id)
-        values.put(BaseDao.MovieEntry.COLUMN_MOVIE_TITLE, movie.title)
-        values.put(BaseDao.MovieEntry.COlUMN_POSTER_PATH, movie.posterPath)
-        values.put(BaseDao.MovieEntry.COLUMN_RUNTIME, movie.runtime)
-        values.put(BaseDao.MovieEntry.COLUMN_VOTE_AVERAGE, movie.voteAverage)
-        values.put(BaseDao.MovieEntry.COLUMN_VOTE_COUNT, movie.voteCount)
-        values.put(BaseDao.MovieEntry.COLUMN_MOVIE_DESCRIPTION, movie.description)
-        values.put(BaseDao.MovieEntry.COLUMN_MOVIE_WATCHED, if (movie.isWatched) 1 else 0)
+        values.put(MovieEntry.ID, movie.id)
+        values.put(MovieEntry.COLUMN_MOVIE_TITLE, movie.title)
+        values.put(MovieEntry.COlUMN_POSTER_PATH, movie.posterPath)
+        values.put(MovieEntry.COLUMN_RUNTIME, movie.runtime)
+        values.put(MovieEntry.COLUMN_VOTE_AVERAGE, movie.voteAverage)
+        values.put(MovieEntry.COLUMN_VOTE_COUNT, movie.voteCount)
+        values.put(MovieEntry.COLUMN_MOVIE_DESCRIPTION, movie.description)
+        values.put(MovieEntry.COLUMN_MOVIE_WATCHED, if (movie.isWatched) 1 else 0)
         val watchDate = movie.watchedDate
         watchDate?.let {
-            values.put(BaseDao.MovieEntry.COLUMN_MOVIE_WATCHED_DATE, watchDate.time)
+            values.put(MovieEntry.COLUMN_MOVIE_WATCHED_DATE, watchDate.time)
         }
         if (movie.releaseDate != null) {
-            values.put(BaseDao.MovieEntry.COLUMN_MOVIE_RELEASE_DATE, sdf.format(movie.releaseDate))
+            values.put(MovieEntry.COLUMN_MOVIE_RELEASE_DATE, sdf.format(movie.releaseDate))
         } else {
-            values.put(BaseDao.MovieEntry.COLUMN_MOVIE_RELEASE_DATE, "")
+            values.put(MovieEntry.COLUMN_MOVIE_RELEASE_DATE, "")
         }
 
-        values.put(BaseDao.MovieEntry.COLUMN_MOVIE_LIST_POSITION, getHighestListPosition(movie.isWatched) + 1)
+        values.put(MovieEntry.COLUMN_MOVIE_LIST_POSITION, getHighestListPosition(movie.isWatched) + 1)
 
-        writeDb.insert(BaseDao.MovieEntry.TABLE_NAME, null, values)
+        writeDb.insert(MovieEntry.TABLE_NAME, null, values)
     }
 
     fun read(selection: String?, selectionArgs: Array<String>?, orderBy: String?): List<Movie> {
         val movies = ArrayList<Movie>()
 
-        val projection = arrayOf(BaseDao.MovieEntry.ID, BaseDao.MovieEntry.COLUMN_MOVIE_TITLE, BaseDao.MovieEntry.COlUMN_POSTER_PATH, BaseDao.MovieEntry.COLUMN_RUNTIME, BaseDao.MovieEntry.COLUMN_VOTE_AVERAGE, BaseDao.MovieEntry.COLUMN_VOTE_COUNT, BaseDao.MovieEntry.COLUMN_MOVIE_DESCRIPTION, BaseDao.MovieEntry.COLUMN_MOVIE_WATCHED, BaseDao.MovieEntry.COLUMN_MOVIE_WATCHED_DATE, BaseDao.MovieEntry.COLUMN_MOVIE_RELEASE_DATE, BaseDao.MovieEntry.COLUMN_MOVIE_LIST_POSITION)
+        val projection = arrayOf(MovieEntry.ID, MovieEntry.COLUMN_MOVIE_TITLE, MovieEntry.COlUMN_POSTER_PATH, MovieEntry.COLUMN_RUNTIME, MovieEntry.COLUMN_VOTE_AVERAGE, MovieEntry.COLUMN_VOTE_COUNT, MovieEntry.COLUMN_MOVIE_DESCRIPTION, MovieEntry.COLUMN_MOVIE_WATCHED, MovieEntry.COLUMN_MOVIE_WATCHED_DATE, MovieEntry.COLUMN_MOVIE_RELEASE_DATE, MovieEntry.COLUMN_MOVIE_LIST_POSITION)
 
         val c = readDb.query(
-                BaseDao.MovieEntry.TABLE_NAME,
+                MovieEntry.TABLE_NAME,
                 projection,
                 selection,
                 selectionArgs, null, null,
@@ -51,23 +51,23 @@ class MovieDao private constructor(context: Context) : BaseDao(context) {
         if (c.moveToFirst()) {
             do {
                 val currentMovie = Movie()
-                currentMovie.id = c.getLong(c.getColumnIndexOrThrow(BaseDao.MovieEntry.ID))
-                currentMovie.title = c.getString(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COLUMN_MOVIE_TITLE))
-                currentMovie.posterPath = c.getString(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COlUMN_POSTER_PATH))
-                currentMovie.runtime = c.getInt(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COLUMN_RUNTIME))
-                currentMovie.voteAverage = c.getDouble(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COLUMN_VOTE_AVERAGE))
-                currentMovie.voteCount = c.getInt(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COLUMN_VOTE_COUNT))
-                currentMovie.description = c.getString(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COLUMN_MOVIE_DESCRIPTION))
-                currentMovie.isWatched = c.getInt(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COLUMN_MOVIE_WATCHED)) > 0
-                currentMovie.watchedDate = Date(c.getLong(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COLUMN_MOVIE_WATCHED_DATE)))
+                currentMovie.id = c.getLong(c.getColumnIndexOrThrow(MovieEntry.ID))
+                currentMovie.title = c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_TITLE))
+                currentMovie.posterPath = c.getString(c.getColumnIndexOrThrow(MovieEntry.COlUMN_POSTER_PATH))
+                currentMovie.runtime = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_RUNTIME))
+                currentMovie.voteAverage = c.getDouble(c.getColumnIndexOrThrow(MovieEntry.COLUMN_VOTE_AVERAGE))
+                currentMovie.voteCount = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_VOTE_COUNT))
+                currentMovie.description = c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_DESCRIPTION))
+                currentMovie.isWatched = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_WATCHED)) > 0
+                currentMovie.watchedDate = Date(c.getLong(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_WATCHED_DATE)))
 
                 try {
-                    currentMovie.releaseDate = sdf.parse(c.getString(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COLUMN_MOVIE_RELEASE_DATE)))
+                    currentMovie.releaseDate = sdf.parse(c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_RELEASE_DATE)))
                 } catch (ex: Exception) {
                     currentMovie.releaseDate = null
                 }
 
-                currentMovie.listPosition = c.getInt(c.getColumnIndexOrThrow(BaseDao.MovieEntry.COLUMN_MOVIE_LIST_POSITION))
+                currentMovie.listPosition = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_LIST_POSITION))
 
                 movies.add(currentMovie)
             } while (c.moveToNext())
@@ -77,24 +77,24 @@ class MovieDao private constructor(context: Context) : BaseDao(context) {
     }
 
     fun update(values: ContentValues, selection: String, selectionArgs: Array<String>) {
-        writeDb.update(BaseDao.MovieEntry.TABLE_NAME, values, selection, selectionArgs)
+        writeDb.update(MovieEntry.TABLE_NAME, values, selection, selectionArgs)
     }
 
     fun delete(id: Long) {
-        writeDb.delete(BaseDao.MovieEntry.TABLE_NAME, BaseDao.MovieEntry.ID + " = ?", arrayOf(id.toString() + ""))
+        writeDb.delete(MovieEntry.TABLE_NAME, MovieEntry.ID + " = ?", arrayOf(id.toString() + ""))
     }
 
     fun getHighestListPosition(watchState: Boolean): Int {
         var highestPos = 0
 
-        val projection = arrayOf("MAX(" + BaseDao.MovieEntry.COLUMN_MOVIE_LIST_POSITION + ") AS POS")
+        val projection = arrayOf("MAX(" + MovieEntry.COLUMN_MOVIE_LIST_POSITION + ") AS POS")
 
-        val selection = BaseDao.MovieEntry.COLUMN_MOVIE_WATCHED + " = ?"
+        val selection = MovieEntry.COLUMN_MOVIE_WATCHED + " = ?"
 
         val selectionArg = if (watchState) "1" else "0"
 
         val c = writeDb.query(
-                BaseDao.MovieEntry.TABLE_NAME,
+                MovieEntry.TABLE_NAME,
                 projection,
                 selection,
                 arrayOf(selectionArg), null, null, null)

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/MovieDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/MovieDao.kt
@@ -31,7 +31,10 @@ class MovieDao private constructor(context: Context) : BaseDao(context) {
             values.put(MovieEntry.COLUMN_MOVIE_RELEASE_DATE, "")
         }
 
-        values.put(MovieEntry.COLUMN_MOVIE_LIST_POSITION, getHighestListPosition(movie.isWatched) + 1)
+        values.put(
+            MovieEntry.COLUMN_MOVIE_LIST_POSITION,
+            getHighestListPosition(movie.isWatched) + 1
+        )
 
         writeDb.insert(MovieEntry.TABLE_NAME, null, values)
     }
@@ -65,13 +68,19 @@ class MovieDao private constructor(context: Context) : BaseDao(context) {
             do {
                 val currentMovie = Movie()
                 currentMovie.id = c.getLong(c.getColumnIndexOrThrow(MovieEntry.ID))
-                currentMovie.title = c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_TITLE))
-                currentMovie.posterPath = c.getString(c.getColumnIndexOrThrow(MovieEntry.COlUMN_POSTER_PATH))
+                currentMovie.title =
+                    c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_TITLE))
+                currentMovie.posterPath =
+                    c.getString(c.getColumnIndexOrThrow(MovieEntry.COlUMN_POSTER_PATH))
                 currentMovie.runtime = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_RUNTIME))
-                currentMovie.voteAverage = c.getDouble(c.getColumnIndexOrThrow(MovieEntry.COLUMN_VOTE_AVERAGE))
-                currentMovie.voteCount = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_VOTE_COUNT))
-                currentMovie.description = c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_DESCRIPTION))
-                currentMovie.isWatched = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_WATCHED)) > 0
+                currentMovie.voteAverage =
+                    c.getDouble(c.getColumnIndexOrThrow(MovieEntry.COLUMN_VOTE_AVERAGE))
+                currentMovie.voteCount =
+                    c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_VOTE_COUNT))
+                currentMovie.description =
+                    c.getString(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_DESCRIPTION))
+                currentMovie.isWatched =
+                    c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_WATCHED)) > 0
                 currentMovie.watchedDate =
                     Date(c.getLong(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_WATCHED_DATE)))
 
@@ -82,7 +91,8 @@ class MovieDao private constructor(context: Context) : BaseDao(context) {
                     currentMovie.releaseDate = null
                 }
 
-                currentMovie.listPosition = c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_LIST_POSITION))
+                currentMovie.listPosition =
+                    c.getInt(c.getColumnIndexOrThrow(MovieEntry.COLUMN_MOVIE_LIST_POSITION))
 
                 movies.add(currentMovie)
             } while (c.moveToNext())

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/SeasonDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/SeasonDao.kt
@@ -64,11 +64,16 @@ class SeasonDao private constructor(context: Context) : BaseDao(context) {
                     currentSeason.releaseDate = null
                 }
 
-                currentSeason.episodeCount = c.getInt(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_EPISODE_COUNT))
-                currentSeason.posterPath = c.getString(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_POSTER_PATH))
-                currentSeason.seasonNumber = c.getInt(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_SEASON_NUMBER))
-                currentSeason.seriesId = c.getLong(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_SERIES_ID))
-                currentSeason.isWatched = c.getInt(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_WATCHED)) > 0
+                currentSeason.episodeCount =
+                    c.getInt(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_EPISODE_COUNT))
+                currentSeason.posterPath =
+                    c.getString(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_POSTER_PATH))
+                currentSeason.seasonNumber =
+                    c.getInt(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_SEASON_NUMBER))
+                currentSeason.seriesId =
+                    c.getLong(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_SERIES_ID))
+                currentSeason.isWatched =
+                    c.getInt(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_WATCHED)) > 0
 
                 seasons.add(currentSeason)
             } while (c.moveToNext())

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/SeasonDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/SeasonDao.kt
@@ -35,21 +35,31 @@ class SeasonDao private constructor(context: Context) : BaseDao(context) {
     fun read(selection: String, selectionArgs: Array<String>): List<Season> {
         val seasons = ArrayList<Season>()
 
-        val projection = arrayOf(SeasonEntry.ID, SeasonEntry.COLUMN_SEASON_RELEASE_DATE, SeasonEntry.COLUMN_SEASON_EPISODE_COUNT, SeasonEntry.COLUMN_SEASON_POSTER_PATH, SeasonEntry.COLUMN_SEASON_SEASON_NUMBER, SeasonEntry.COLUMN_SEASON_SERIES_ID, SeasonEntry.COLUMN_SEASON_WATCHED)
+        val projection = arrayOf(
+            SeasonEntry.ID,
+            SeasonEntry.COLUMN_SEASON_RELEASE_DATE,
+            SeasonEntry.COLUMN_SEASON_EPISODE_COUNT,
+            SeasonEntry.COLUMN_SEASON_POSTER_PATH,
+            SeasonEntry.COLUMN_SEASON_SEASON_NUMBER,
+            SeasonEntry.COLUMN_SEASON_SERIES_ID,
+            SeasonEntry.COLUMN_SEASON_WATCHED
+        )
 
         val c = readDb.query(
-                SeasonEntry.TABLE_NAME,
-                projection,
-                selection,
-                selectionArgs, null, null,
-                SeasonEntry.COLUMN_SEASON_SEASON_NUMBER + " ASC", null)
+            SeasonEntry.TABLE_NAME,
+            projection,
+            selection,
+            selectionArgs, null, null,
+            SeasonEntry.COLUMN_SEASON_SEASON_NUMBER + " ASC", null
+        )
 
         if (c.moveToFirst()) {
             do {
                 val currentSeason = Season()
                 currentSeason.id = c.getLong(c.getColumnIndexOrThrow(SeasonEntry.ID))
                 try {
-                    currentSeason.releaseDate = sdf.parse(c.getString(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_RELEASE_DATE)))
+                    currentSeason.releaseDate =
+                        sdf.parse(c.getString(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_RELEASE_DATE)))
                 } catch (ex: ParseException) {
                     currentSeason.releaseDate = null
                 }
@@ -92,7 +102,11 @@ class SeasonDao private constructor(context: Context) : BaseDao(context) {
     }
 
     fun deleteBySeriesId(id: Long) {
-        writeDb.delete(SeasonEntry.TABLE_NAME, SeasonEntry.COLUMN_SEASON_SERIES_ID + " = ?", arrayOf(id.toString() + ""))
+        writeDb.delete(
+            SeasonEntry.TABLE_NAME,
+            SeasonEntry.COLUMN_SEASON_SERIES_ID + " = ?",
+            arrayOf(id.toString() + "")
+        )
     }
 
     companion object {

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/SeasonDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/SeasonDao.kt
@@ -17,48 +17,48 @@ class SeasonDao private constructor(context: Context) : BaseDao(context) {
             // exclude specials if present
         }
         val values = ContentValues()
-        values.put(BaseDao.SeasonEntry.ID, season.id)
+        values.put(SeasonEntry.ID, season.id)
         if (season.releaseDate == null) {
-            values.put(BaseDao.SeasonEntry.COLUMN_SEASON_RELEASE_DATE, "")
+            values.put(SeasonEntry.COLUMN_SEASON_RELEASE_DATE, "")
         } else {
-            values.put(BaseDao.SeasonEntry.COLUMN_SEASON_RELEASE_DATE, sdf.format(season.releaseDate))
+            values.put(SeasonEntry.COLUMN_SEASON_RELEASE_DATE, sdf.format(season.releaseDate))
         }
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_EPISODE_COUNT, season.episodeCount)
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_POSTER_PATH, season.posterPath)
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_SEASON_NUMBER, season.seasonNumber)
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_SERIES_ID, seriesId)
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_WATCHED, if (season.isWatched) 1 else 0)
+        values.put(SeasonEntry.COLUMN_SEASON_EPISODE_COUNT, season.episodeCount)
+        values.put(SeasonEntry.COLUMN_SEASON_POSTER_PATH, season.posterPath)
+        values.put(SeasonEntry.COLUMN_SEASON_SEASON_NUMBER, season.seasonNumber)
+        values.put(SeasonEntry.COLUMN_SEASON_SERIES_ID, seriesId)
+        values.put(SeasonEntry.COLUMN_SEASON_WATCHED, if (season.isWatched) 1 else 0)
 
-        writeDb.insert(BaseDao.SeasonEntry.TABLE_NAME, null, values)
+        writeDb.insert(SeasonEntry.TABLE_NAME, null, values)
     }
 
     fun read(selection: String, selectionArgs: Array<String>): List<Season> {
         val seasons = ArrayList<Season>()
 
-        val projection = arrayOf(BaseDao.SeasonEntry.ID, BaseDao.SeasonEntry.COLUMN_SEASON_RELEASE_DATE, BaseDao.SeasonEntry.COLUMN_SEASON_EPISODE_COUNT, BaseDao.SeasonEntry.COLUMN_SEASON_POSTER_PATH, BaseDao.SeasonEntry.COLUMN_SEASON_SEASON_NUMBER, BaseDao.SeasonEntry.COLUMN_SEASON_SERIES_ID, BaseDao.SeasonEntry.COLUMN_SEASON_WATCHED)
+        val projection = arrayOf(SeasonEntry.ID, SeasonEntry.COLUMN_SEASON_RELEASE_DATE, SeasonEntry.COLUMN_SEASON_EPISODE_COUNT, SeasonEntry.COLUMN_SEASON_POSTER_PATH, SeasonEntry.COLUMN_SEASON_SEASON_NUMBER, SeasonEntry.COLUMN_SEASON_SERIES_ID, SeasonEntry.COLUMN_SEASON_WATCHED)
 
         val c = readDb.query(
-                BaseDao.SeasonEntry.TABLE_NAME,
+                SeasonEntry.TABLE_NAME,
                 projection,
                 selection,
                 selectionArgs, null, null,
-                BaseDao.SeasonEntry.COLUMN_SEASON_SEASON_NUMBER + " ASC", null)
+                SeasonEntry.COLUMN_SEASON_SEASON_NUMBER + " ASC", null)
 
         if (c.moveToFirst()) {
             do {
                 val currentSeason = Season()
-                currentSeason.id = c.getLong(c.getColumnIndexOrThrow(BaseDao.SeasonEntry.ID))
+                currentSeason.id = c.getLong(c.getColumnIndexOrThrow(SeasonEntry.ID))
                 try {
-                    currentSeason.releaseDate = sdf.parse(c.getString(c.getColumnIndexOrThrow(BaseDao.SeasonEntry.COLUMN_SEASON_RELEASE_DATE)))
+                    currentSeason.releaseDate = sdf.parse(c.getString(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_RELEASE_DATE)))
                 } catch (ex: ParseException) {
                     currentSeason.releaseDate = null
                 }
 
-                currentSeason.episodeCount = c.getInt(c.getColumnIndexOrThrow(BaseDao.SeasonEntry.COLUMN_SEASON_EPISODE_COUNT))
-                currentSeason.posterPath = c.getString(c.getColumnIndexOrThrow(BaseDao.SeasonEntry.COLUMN_SEASON_POSTER_PATH))
-                currentSeason.seasonNumber = c.getInt(c.getColumnIndexOrThrow(BaseDao.SeasonEntry.COLUMN_SEASON_SEASON_NUMBER))
-                currentSeason.seriesId = c.getLong(c.getColumnIndexOrThrow(BaseDao.SeasonEntry.COLUMN_SEASON_SERIES_ID))
-                currentSeason.isWatched = c.getInt(c.getColumnIndexOrThrow(BaseDao.SeasonEntry.COLUMN_SEASON_WATCHED)) > 0
+                currentSeason.episodeCount = c.getInt(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_EPISODE_COUNT))
+                currentSeason.posterPath = c.getString(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_POSTER_PATH))
+                currentSeason.seasonNumber = c.getInt(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_SEASON_NUMBER))
+                currentSeason.seriesId = c.getLong(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_SERIES_ID))
+                currentSeason.isWatched = c.getInt(c.getColumnIndexOrThrow(SeasonEntry.COLUMN_SEASON_WATCHED)) > 0
 
                 seasons.add(currentSeason)
             } while (c.moveToNext())
@@ -72,27 +72,27 @@ class SeasonDao private constructor(context: Context) : BaseDao(context) {
             return
         }
         val values = ContentValues()
-        values.put(BaseDao.SeasonEntry.ID, season.id)
+        values.put(SeasonEntry.ID, season.id)
 
         if (season.releaseDate == null) {
-            values.put(BaseDao.SeasonEntry.COLUMN_SEASON_RELEASE_DATE, "")
+            values.put(SeasonEntry.COLUMN_SEASON_RELEASE_DATE, "")
         } else {
-            values.put(BaseDao.SeasonEntry.COLUMN_SEASON_RELEASE_DATE, sdf.format(season.releaseDate))
+            values.put(SeasonEntry.COLUMN_SEASON_RELEASE_DATE, sdf.format(season.releaseDate))
         }
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_EPISODE_COUNT, season.episodeCount)
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_POSTER_PATH, season.posterPath)
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_SEASON_NUMBER, season.seasonNumber)
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_SERIES_ID, season.seriesId)
-        values.put(BaseDao.SeasonEntry.COLUMN_SEASON_WATCHED, if (season.isWatched) 1 else 0)
+        values.put(SeasonEntry.COLUMN_SEASON_EPISODE_COUNT, season.episodeCount)
+        values.put(SeasonEntry.COLUMN_SEASON_POSTER_PATH, season.posterPath)
+        values.put(SeasonEntry.COLUMN_SEASON_SEASON_NUMBER, season.seasonNumber)
+        values.put(SeasonEntry.COLUMN_SEASON_SERIES_ID, season.seriesId)
+        values.put(SeasonEntry.COLUMN_SEASON_WATCHED, if (season.isWatched) 1 else 0)
 
-        val selection = BaseDao.SeasonEntry.ID + " LIKE ?"
+        val selection = SeasonEntry.ID + " LIKE ?"
         val selectionArgs = arrayOf(season.id.toString())
 
-        writeDb.update(BaseDao.SeasonEntry.TABLE_NAME, values, selection, selectionArgs)
+        writeDb.update(SeasonEntry.TABLE_NAME, values, selection, selectionArgs)
     }
 
     fun deleteBySeriesId(id: Long) {
-        writeDb.delete(BaseDao.SeasonEntry.TABLE_NAME, BaseDao.SeasonEntry.COLUMN_SEASON_SERIES_ID + " = ?", arrayOf(id.toString() + ""))
+        writeDb.delete(SeasonEntry.TABLE_NAME, SeasonEntry.COLUMN_SEASON_SERIES_ID + " = ?", arrayOf(id.toString() + ""))
     }
 
     companion object {

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/SeriesDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/SeriesDao.kt
@@ -28,7 +28,10 @@ class SeriesDao private constructor(context: Context) : BaseDao(context) {
         values.put(SeriesEntry.COLUMN_SERIES_POSTER_PATH, series.posterPath)
         values.put(SeriesEntry.COLUMN_SERIES_BACKDROP_PATH, series.backdropPath)
         values.put(SeriesEntry.COLUMN_SERIES_SERIES_WATCHED, if (series.isWatched) 1 else 0)
-        values.put(SeriesEntry.COLUMN_SERIES_LIST_POSITION, getHighestListPosition(series.isWatched))
+        values.put(
+            SeriesEntry.COLUMN_SERIES_LIST_POSITION,
+            getHighestListPosition(series.isWatched)
+        )
 
         writeDb.insert(SeriesEntry.TABLE_NAME, null, values)
     }
@@ -64,10 +67,14 @@ class SeriesDao private constructor(context: Context) : BaseDao(context) {
             do {
                 val currentSeries = Series()
                 currentSeries.id = c.getLong(c.getColumnIndexOrThrow(SeriesEntry.ID))
-                currentSeries.name = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NAME))
-                currentSeries.voteAverage = c.getDouble(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE))
-                currentSeries.voteCount = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_VOTE_COUNT))
-                currentSeries.description = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_DESCRIPTION))
+                currentSeries.name =
+                    c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NAME))
+                currentSeries.voteAverage =
+                    c.getDouble(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE))
+                currentSeries.voteCount =
+                    c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_VOTE_COUNT))
+                currentSeries.description =
+                    c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_DESCRIPTION))
                 try {
                     currentSeries.releaseDate =
                         sdf.parse(c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_RELEASE_DATE)))
@@ -81,12 +88,14 @@ class SeriesDao private constructor(context: Context) : BaseDao(context) {
                     c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES))
                 currentSeries.numberOfSeasons =
                     c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS))
-                currentSeries.posterPath = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_POSTER_PATH))
+                currentSeries.posterPath =
+                    c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_POSTER_PATH))
                 currentSeries.backdropPath =
                     c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_BACKDROP_PATH))
                 currentSeries.isWatched =
                     c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_SERIES_WATCHED)) > 0
-                currentSeries.listPosition = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_LIST_POSITION))
+                currentSeries.listPosition =
+                    c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_LIST_POSITION))
 
                 series.add(currentSeries)
             } while (c.moveToNext())

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/SeriesDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/SeriesDao.kt
@@ -36,14 +36,29 @@ class SeriesDao private constructor(context: Context) : BaseDao(context) {
     fun read(selection: String?, selectionArgs: Array<String>?, orderBy: String?): List<Series> {
         val series = ArrayList<Series>()
 
-        val projection = arrayOf(SeriesEntry.ID, SeriesEntry.COLUMN_SERIES_NAME, SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE, SeriesEntry.COLUMN_SERIES_VOTE_COUNT, SeriesEntry.COLUMN_SERIES_DESCRIPTION, SeriesEntry.COLUMN_SERIES_RELEASE_DATE, SeriesEntry.COLUMN_SERIES_IN_PRODUCTION, SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES, SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS, SeriesEntry.COLUMN_SERIES_POSTER_PATH, SeriesEntry.COLUMN_SERIES_BACKDROP_PATH, SeriesEntry.COLUMN_SERIES_SERIES_WATCHED, SeriesEntry.COLUMN_SERIES_LIST_POSITION)
+        val projection = arrayOf(
+            SeriesEntry.ID,
+            SeriesEntry.COLUMN_SERIES_NAME,
+            SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE,
+            SeriesEntry.COLUMN_SERIES_VOTE_COUNT,
+            SeriesEntry.COLUMN_SERIES_DESCRIPTION,
+            SeriesEntry.COLUMN_SERIES_RELEASE_DATE,
+            SeriesEntry.COLUMN_SERIES_IN_PRODUCTION,
+            SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES,
+            SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS,
+            SeriesEntry.COLUMN_SERIES_POSTER_PATH,
+            SeriesEntry.COLUMN_SERIES_BACKDROP_PATH,
+            SeriesEntry.COLUMN_SERIES_SERIES_WATCHED,
+            SeriesEntry.COLUMN_SERIES_LIST_POSITION
+        )
 
         val c = readDb.query(
-                SeriesEntry.TABLE_NAME,
-                projection,
-                selection,
-                selectionArgs, null, null,
-                orderBy, null)
+            SeriesEntry.TABLE_NAME,
+            projection,
+            selection,
+            selectionArgs, null, null,
+            orderBy, null
+        )
 
         if (c.moveToFirst()) {
             do {
@@ -54,17 +69,23 @@ class SeriesDao private constructor(context: Context) : BaseDao(context) {
                 currentSeries.voteCount = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_VOTE_COUNT))
                 currentSeries.description = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_DESCRIPTION))
                 try {
-                    currentSeries.releaseDate = sdf.parse(c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_RELEASE_DATE)))
+                    currentSeries.releaseDate =
+                        sdf.parse(c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_RELEASE_DATE)))
                 } catch (ex: Exception) {
                     currentSeries.releaseDate = null
                 }
 
-                currentSeries.isInProduction = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_IN_PRODUCTION)) > 0
-                currentSeries.numberOfEpisodes = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES))
-                currentSeries.numberOfSeasons = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS))
+                currentSeries.isInProduction =
+                    c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_IN_PRODUCTION)) > 0
+                currentSeries.numberOfEpisodes =
+                    c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES))
+                currentSeries.numberOfSeasons =
+                    c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS))
                 currentSeries.posterPath = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_POSTER_PATH))
-                currentSeries.backdropPath = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_BACKDROP_PATH))
-                currentSeries.isWatched = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_SERIES_WATCHED)) > 0
+                currentSeries.backdropPath =
+                    c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_BACKDROP_PATH))
+                currentSeries.isWatched =
+                    c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_SERIES_WATCHED)) > 0
                 currentSeries.listPosition = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_LIST_POSITION))
 
                 series.add(currentSeries)
@@ -114,10 +135,11 @@ class SeriesDao private constructor(context: Context) : BaseDao(context) {
         val selectionArg = if (watchState) "1" else "0"
 
         val c = writeDb.query(
-                SeriesEntry.TABLE_NAME,
-                projection,
-                selection,
-                arrayOf(selectionArg), null, null, null)
+            SeriesEntry.TABLE_NAME,
+            projection,
+            selection,
+            arrayOf(selectionArg), null, null, null
+        )
         if (c.moveToFirst()) {
             do {
                 highestPos = c.getInt(c.getColumnIndex("POS"))

--- a/app/src/main/kotlin/de/cineaste/android/database/dao/SeriesDao.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dao/SeriesDao.kt
@@ -12,34 +12,34 @@ class SeriesDao private constructor(context: Context) : BaseDao(context) {
 
     fun create(series: Series) {
         val values = ContentValues()
-        values.put(BaseDao.SeriesEntry.ID, series.id)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_NAME, series.name)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE, series.voteAverage)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_VOTE_COUNT, series.voteCount)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_DESCRIPTION, series.description)
+        values.put(SeriesEntry.ID, series.id)
+        values.put(SeriesEntry.COLUMN_SERIES_NAME, series.name)
+        values.put(SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE, series.voteAverage)
+        values.put(SeriesEntry.COLUMN_SERIES_VOTE_COUNT, series.voteCount)
+        values.put(SeriesEntry.COLUMN_SERIES_DESCRIPTION, series.description)
         if (series.releaseDate == null) {
-            values.put(BaseDao.SeriesEntry.COLUMN_SERIES_RELEASE_DATE, "")
+            values.put(SeriesEntry.COLUMN_SERIES_RELEASE_DATE, "")
         } else {
-            values.put(BaseDao.SeriesEntry.COLUMN_SERIES_RELEASE_DATE, sdf.format(series.releaseDate))
+            values.put(SeriesEntry.COLUMN_SERIES_RELEASE_DATE, sdf.format(series.releaseDate))
         }
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_IN_PRODUCTION, if (series.isInProduction) 1 else 0)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES, series.numberOfEpisodes)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS, series.numberOfSeasons)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_POSTER_PATH, series.posterPath)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_BACKDROP_PATH, series.backdropPath)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_SERIES_WATCHED, if (series.isWatched) 1 else 0)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_LIST_POSITION, getHighestListPosition(series.isWatched))
+        values.put(SeriesEntry.COLUMN_SERIES_IN_PRODUCTION, if (series.isInProduction) 1 else 0)
+        values.put(SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES, series.numberOfEpisodes)
+        values.put(SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS, series.numberOfSeasons)
+        values.put(SeriesEntry.COLUMN_SERIES_POSTER_PATH, series.posterPath)
+        values.put(SeriesEntry.COLUMN_SERIES_BACKDROP_PATH, series.backdropPath)
+        values.put(SeriesEntry.COLUMN_SERIES_SERIES_WATCHED, if (series.isWatched) 1 else 0)
+        values.put(SeriesEntry.COLUMN_SERIES_LIST_POSITION, getHighestListPosition(series.isWatched))
 
-        writeDb.insert(BaseDao.SeriesEntry.TABLE_NAME, null, values)
+        writeDb.insert(SeriesEntry.TABLE_NAME, null, values)
     }
 
     fun read(selection: String?, selectionArgs: Array<String>?, orderBy: String?): List<Series> {
         val series = ArrayList<Series>()
 
-        val projection = arrayOf(BaseDao.SeriesEntry.ID, BaseDao.SeriesEntry.COLUMN_SERIES_NAME, BaseDao.SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE, BaseDao.SeriesEntry.COLUMN_SERIES_VOTE_COUNT, BaseDao.SeriesEntry.COLUMN_SERIES_DESCRIPTION, BaseDao.SeriesEntry.COLUMN_SERIES_RELEASE_DATE, BaseDao.SeriesEntry.COLUMN_SERIES_IN_PRODUCTION, BaseDao.SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES, BaseDao.SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS, BaseDao.SeriesEntry.COLUMN_SERIES_POSTER_PATH, BaseDao.SeriesEntry.COLUMN_SERIES_BACKDROP_PATH, BaseDao.SeriesEntry.COLUMN_SERIES_SERIES_WATCHED, BaseDao.SeriesEntry.COLUMN_SERIES_LIST_POSITION)
+        val projection = arrayOf(SeriesEntry.ID, SeriesEntry.COLUMN_SERIES_NAME, SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE, SeriesEntry.COLUMN_SERIES_VOTE_COUNT, SeriesEntry.COLUMN_SERIES_DESCRIPTION, SeriesEntry.COLUMN_SERIES_RELEASE_DATE, SeriesEntry.COLUMN_SERIES_IN_PRODUCTION, SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES, SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS, SeriesEntry.COLUMN_SERIES_POSTER_PATH, SeriesEntry.COLUMN_SERIES_BACKDROP_PATH, SeriesEntry.COLUMN_SERIES_SERIES_WATCHED, SeriesEntry.COLUMN_SERIES_LIST_POSITION)
 
         val c = readDb.query(
-                BaseDao.SeriesEntry.TABLE_NAME,
+                SeriesEntry.TABLE_NAME,
                 projection,
                 selection,
                 selectionArgs, null, null,
@@ -48,24 +48,24 @@ class SeriesDao private constructor(context: Context) : BaseDao(context) {
         if (c.moveToFirst()) {
             do {
                 val currentSeries = Series()
-                currentSeries.id = c.getLong(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.ID))
-                currentSeries.name = c.getString(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_NAME))
-                currentSeries.voteAverage = c.getDouble(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE))
-                currentSeries.voteCount = c.getInt(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_VOTE_COUNT))
-                currentSeries.description = c.getString(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_DESCRIPTION))
+                currentSeries.id = c.getLong(c.getColumnIndexOrThrow(SeriesEntry.ID))
+                currentSeries.name = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NAME))
+                currentSeries.voteAverage = c.getDouble(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE))
+                currentSeries.voteCount = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_VOTE_COUNT))
+                currentSeries.description = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_DESCRIPTION))
                 try {
-                    currentSeries.releaseDate = sdf.parse(c.getString(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_RELEASE_DATE)))
+                    currentSeries.releaseDate = sdf.parse(c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_RELEASE_DATE)))
                 } catch (ex: Exception) {
                     currentSeries.releaseDate = null
                 }
 
-                currentSeries.isInProduction = c.getInt(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_IN_PRODUCTION)) > 0
-                currentSeries.numberOfEpisodes = c.getInt(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES))
-                currentSeries.numberOfSeasons = c.getInt(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS))
-                currentSeries.posterPath = c.getString(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_POSTER_PATH))
-                currentSeries.backdropPath = c.getString(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_BACKDROP_PATH))
-                currentSeries.isWatched = c.getInt(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_SERIES_WATCHED)) > 0
-                currentSeries.listPosition = c.getInt(c.getColumnIndexOrThrow(BaseDao.SeriesEntry.COLUMN_SERIES_LIST_POSITION))
+                currentSeries.isInProduction = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_IN_PRODUCTION)) > 0
+                currentSeries.numberOfEpisodes = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES))
+                currentSeries.numberOfSeasons = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS))
+                currentSeries.posterPath = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_POSTER_PATH))
+                currentSeries.backdropPath = c.getString(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_BACKDROP_PATH))
+                currentSeries.isWatched = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_SERIES_WATCHED)) > 0
+                currentSeries.listPosition = c.getInt(c.getColumnIndexOrThrow(SeriesEntry.COLUMN_SERIES_LIST_POSITION))
 
                 series.add(currentSeries)
             } while (c.moveToNext())
@@ -76,45 +76,45 @@ class SeriesDao private constructor(context: Context) : BaseDao(context) {
 
     fun update(series: Series, listPosition: Int) {
         val values = ContentValues()
-        values.put(BaseDao.SeriesEntry.ID, series.id)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_NAME, series.name)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE, series.voteAverage)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_VOTE_COUNT, series.voteCount)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_DESCRIPTION, series.description)
+        values.put(SeriesEntry.ID, series.id)
+        values.put(SeriesEntry.COLUMN_SERIES_NAME, series.name)
+        values.put(SeriesEntry.COLUMN_SERIES_VOTE_AVERAGE, series.voteAverage)
+        values.put(SeriesEntry.COLUMN_SERIES_VOTE_COUNT, series.voteCount)
+        values.put(SeriesEntry.COLUMN_SERIES_DESCRIPTION, series.description)
         if (series.releaseDate == null) {
-            values.put(BaseDao.SeriesEntry.COLUMN_SERIES_RELEASE_DATE, "")
+            values.put(SeriesEntry.COLUMN_SERIES_RELEASE_DATE, "")
         } else {
-            values.put(BaseDao.SeriesEntry.COLUMN_SERIES_RELEASE_DATE, sdf.format(series.releaseDate))
+            values.put(SeriesEntry.COLUMN_SERIES_RELEASE_DATE, sdf.format(series.releaseDate))
         }
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_IN_PRODUCTION, if (series.isInProduction) 1 else 0)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES, series.numberOfEpisodes)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS, series.numberOfSeasons)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_POSTER_PATH, series.posterPath)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_BACKDROP_PATH, series.backdropPath)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_SERIES_WATCHED, if (series.isWatched) 1 else 0)
-        values.put(BaseDao.SeriesEntry.COLUMN_SERIES_LIST_POSITION, listPosition)
+        values.put(SeriesEntry.COLUMN_SERIES_IN_PRODUCTION, if (series.isInProduction) 1 else 0)
+        values.put(SeriesEntry.COLUMN_SERIES_NUMBER_OF_EPISODES, series.numberOfEpisodes)
+        values.put(SeriesEntry.COLUMN_SERIES_NUMBER_OF_SEASONS, series.numberOfSeasons)
+        values.put(SeriesEntry.COLUMN_SERIES_POSTER_PATH, series.posterPath)
+        values.put(SeriesEntry.COLUMN_SERIES_BACKDROP_PATH, series.backdropPath)
+        values.put(SeriesEntry.COLUMN_SERIES_SERIES_WATCHED, if (series.isWatched) 1 else 0)
+        values.put(SeriesEntry.COLUMN_SERIES_LIST_POSITION, listPosition)
 
-        val selection = BaseDao.SeriesEntry.ID + " LIKE ?"
+        val selection = SeriesEntry.ID + " LIKE ?"
         val selectionArgs = arrayOf(series.id.toString())
 
-        writeDb.update(BaseDao.SeriesEntry.TABLE_NAME, values, selection, selectionArgs)
+        writeDb.update(SeriesEntry.TABLE_NAME, values, selection, selectionArgs)
     }
 
     fun delete(id: Long) {
-        writeDb.delete(BaseDao.SeriesEntry.TABLE_NAME, BaseDao.SeriesEntry.ID + " = ?", arrayOf(id.toString() + ""))
+        writeDb.delete(SeriesEntry.TABLE_NAME, SeriesEntry.ID + " = ?", arrayOf(id.toString() + ""))
     }
 
     fun getHighestListPosition(watchState: Boolean): Int {
         var highestPos = 0
 
-        val projection = arrayOf("MAX(" + BaseDao.SeriesEntry.COLUMN_SERIES_LIST_POSITION + ") AS POS")
+        val projection = arrayOf("MAX(" + SeriesEntry.COLUMN_SERIES_LIST_POSITION + ") AS POS")
 
-        val selection = BaseDao.SeriesEntry.COLUMN_SERIES_SERIES_WATCHED + " = ?"
+        val selection = SeriesEntry.COLUMN_SERIES_SERIES_WATCHED + " = ?"
 
         val selectionArg = if (watchState) "1" else "0"
 
         val c = writeDb.query(
-                BaseDao.SeriesEntry.TABLE_NAME,
+                SeriesEntry.TABLE_NAME,
                 projection,
                 selection,
                 arrayOf(selectionArg), null, null, null)

--- a/app/src/main/kotlin/de/cineaste/android/database/dbHelper/MovieDbHelper.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dbHelper/MovieDbHelper.kt
@@ -32,7 +32,11 @@ class MovieDbHelper private constructor(context: Context) {
         val selection = BaseDao.MovieEntry.COLUMN_MOVIE_WATCHED + " = ?"
         val selectionArgs = arrayOf(selectionArg)
 
-        return movieDao.read(selection, selectionArgs, BaseDao.MovieEntry.COLUMN_MOVIE_LIST_POSITION + " ASC")
+        return movieDao.read(
+            selection,
+            selectionArgs,
+            BaseDao.MovieEntry.COLUMN_MOVIE_LIST_POSITION + " ASC"
+        )
     }
 
     fun reorderAlphabetical(state: WatchState): List<Movie> {

--- a/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
@@ -1,10 +1,10 @@
 package de.cineaste.android.database.dbHelper
 
 import android.content.Context
-
 import java.util.ArrayList
-
-import de.cineaste.android.database.dao.BaseDao
+import de.cineaste.android.database.dao.BaseDao.EpisodeEntry
+import de.cineaste.android.database.dao.BaseDao.SeasonEntry
+import de.cineaste.android.database.dao.BaseDao.SeriesEntry
 import de.cineaste.android.database.dao.EpisodeDao
 import de.cineaste.android.database.dao.SeasonDao
 import de.cineaste.android.database.dao.SeriesDao
@@ -12,10 +12,6 @@ import de.cineaste.android.entity.series.Episode
 import de.cineaste.android.entity.series.Season
 import de.cineaste.android.entity.series.Series
 import de.cineaste.android.fragment.WatchState
-
-import de.cineaste.android.database.dao.BaseDao.EpisodeEntry
-import de.cineaste.android.database.dao.BaseDao.SeasonEntry
-import de.cineaste.android.database.dao.BaseDao.SeriesEntry
 
 class SeriesDbHelper private constructor(context: Context) {
 

--- a/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
@@ -199,7 +199,12 @@ class SeriesDbHelper private constructor(context: Context) {
         moveBackToList(series, prevSeason, prevEpisode, true)
     }
 
-    private fun moveBackToList(series: Series, prevSeason: Int, prevEpisode: Int, watchState: Boolean) {
+    private fun moveBackToList(
+        series: Series,
+        prevSeason: Int,
+        prevEpisode: Int,
+        watchState: Boolean
+    ) {
         moveBetweenLists(series, watchState)
         for (season in series.seasons) {
             if (season.seasonNumber < prevSeason) {

--- a/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
@@ -51,7 +51,11 @@ class SeriesDbHelper private constructor(context: Context) {
         val selection = SeriesEntry.COLUMN_SERIES_SERIES_WATCHED + " = ?"
         val selectionArgs = arrayOf(selectionArg)
 
-        val seriesList = seriesDao.read(selection, selectionArgs, SeriesEntry.COLUMN_SERIES_LIST_POSITION + " ASC")
+        val seriesList = seriesDao.read(
+            selection,
+            selectionArgs,
+            SeriesEntry.COLUMN_SERIES_LIST_POSITION + " ASC"
+        )
 
         for (series in seriesList) {
             loadRemainingInformation(series)

--- a/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
@@ -65,14 +65,14 @@ class SeriesDbHelper private constructor(context: Context) {
     }
 
     fun getUnWatchedEpisodesOfSeries(seriesId: Long): List<Episode> {
-        val selection = BaseDao.EpisodeEntry.COLUMN_EPISODE_SERIES_ID + " = ? AND " + BaseDao.EpisodeEntry.COLUMN_EPISODE_WATCHED + " = 0"
+        val selection = EpisodeEntry.COLUMN_EPISODE_SERIES_ID + " = ? AND " + EpisodeEntry.COLUMN_EPISODE_WATCHED + " = 0"
         val selectionArgs = arrayOf(seriesId.toString())
 
         return episodeDao.read(selection, selectionArgs)
     }
 
     fun getEpisodesBySeasonId(seasonId: Long): List<Episode> {
-        val selection = BaseDao.EpisodeEntry.COLUMN_EPISODE_SEASON_ID + " = ?"
+        val selection = EpisodeEntry.COLUMN_EPISODE_SEASON_ID + " = ?"
         val selectionArgs = arrayOf(seasonId.toString())
 
         return episodeDao.read(selection, selectionArgs)

--- a/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dbHelper/SeriesDbHelper.kt
@@ -61,7 +61,8 @@ class SeriesDbHelper private constructor(context: Context) {
     }
 
     fun getUnWatchedEpisodesOfSeries(seriesId: Long): List<Episode> {
-        val selection = EpisodeEntry.COLUMN_EPISODE_SERIES_ID + " = ? AND " + EpisodeEntry.COLUMN_EPISODE_WATCHED + " = 0"
+        val selection =
+            EpisodeEntry.COLUMN_EPISODE_SERIES_ID + " = ? AND " + EpisodeEntry.COLUMN_EPISODE_WATCHED + " = 0"
         val selectionArgs = arrayOf(seriesId.toString())
 
         return episodeDao.read(selection, selectionArgs)

--- a/app/src/main/kotlin/de/cineaste/android/database/dbHelper/UserDbHelper.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dbHelper/UserDbHelper.kt
@@ -10,10 +10,10 @@ class UserDbHelper private constructor(context: Context) : BaseDao(context) {
     val user: User?
         get() {
 
-            val projection = arrayOf(BaseDao.UserEntry.ID, BaseDao.UserEntry.COLUMN_USER_NAME)
+            val projection = arrayOf(UserEntry.ID, UserEntry.COLUMN_USER_NAME)
 
             val c = readDb.query(
-                    BaseDao.UserEntry.TABLE_NAME,
+                    UserEntry.TABLE_NAME,
                     projection,
                     null, null, null, null, null, null)
 
@@ -22,7 +22,7 @@ class UserDbHelper private constructor(context: Context) : BaseDao(context) {
             if (c.moveToFirst()) {
                 do {
                     user = User()
-                    user.userName = c.getString(c.getColumnIndexOrThrow(BaseDao.UserEntry.COLUMN_USER_NAME))
+                    user.userName = c.getString(c.getColumnIndexOrThrow(UserEntry.COLUMN_USER_NAME))
                 } while (c.moveToNext())
             }
             c.close()
@@ -31,9 +31,9 @@ class UserDbHelper private constructor(context: Context) : BaseDao(context) {
 
     fun createUser(user: User) {
         val values = ContentValues()
-        values.put(BaseDao.UserEntry.COLUMN_USER_NAME, user.userName)
+        values.put(UserEntry.COLUMN_USER_NAME, user.userName)
 
-        writeDb.insert(BaseDao.UserEntry.TABLE_NAME, null, values)
+        writeDb.insert(UserEntry.TABLE_NAME, null, values)
     }
 
     companion object {

--- a/app/src/main/kotlin/de/cineaste/android/database/dbHelper/UserDbHelper.kt
+++ b/app/src/main/kotlin/de/cineaste/android/database/dbHelper/UserDbHelper.kt
@@ -13,9 +13,10 @@ class UserDbHelper private constructor(context: Context) : BaseDao(context) {
             val projection = arrayOf(UserEntry.ID, UserEntry.COLUMN_USER_NAME)
 
             val c = readDb.query(
-                    UserEntry.TABLE_NAME,
-                    projection,
-                    null, null, null, null, null, null)
+                UserEntry.TABLE_NAME,
+                projection,
+                null, null, null, null, null, null
+            )
 
             var user: User? = null
 

--- a/app/src/main/kotlin/de/cineaste/android/entity/movie/MatchingResult.kt
+++ b/app/src/main/kotlin/de/cineaste/android/entity/movie/MatchingResult.kt
@@ -9,5 +9,10 @@ data class MatchingResult(
     var title: String = "",
     val counter: Int
 ) {
-    constructor(movieDto: MovieDto, counter: Int) : this(movieDto.id, movieDto.posterPath, movieDto.title, counter)
+    constructor(movieDto: MovieDto, counter: Int) : this(
+        movieDto.id,
+        movieDto.posterPath,
+        movieDto.title,
+        counter
+    )
 }

--- a/app/src/main/kotlin/de/cineaste/android/entity/movie/MatchingResult.kt
+++ b/app/src/main/kotlin/de/cineaste/android/entity/movie/MatchingResult.kt
@@ -9,5 +9,5 @@ data class MatchingResult(
     var title: String = "",
     val counter: Int
 ) {
-    constructor(movieDto: MovieDto, counter: Int): this(movieDto.id, movieDto.posterPath, movieDto.title, counter)
+    constructor(movieDto: MovieDto, counter: Int) : this(movieDto.id, movieDto.posterPath, movieDto.title, counter)
 }

--- a/app/src/main/kotlin/de/cineaste/android/entity/movie/NearbyMessage.kt
+++ b/app/src/main/kotlin/de/cineaste/android/entity/movie/NearbyMessage.kt
@@ -38,8 +38,9 @@ data class NearbyMessage(
             val nearbyMessageString = String(message.content).trim { it <= ' ' }
 
             return GSON.fromJson(
-                    String(nearbyMessageString.toByteArray(Charsets.UTF_8)),
-                    NearbyMessage::class.java)
+                String(nearbyMessageString.toByteArray(Charsets.UTF_8)),
+                NearbyMessage::class.java
+            )
         }
     }
 }

--- a/app/src/main/kotlin/de/cineaste/android/entity/movie/NearbyMessage.kt
+++ b/app/src/main/kotlin/de/cineaste/android/entity/movie/NearbyMessage.kt
@@ -27,17 +27,17 @@ data class NearbyMessage(
     }
 
     fun toNearbyMessage(): Message {
-        return Message(GSON.toJson(this).toByteArray(Charsets.UTF_8))
+        return Message(gson.toJson(this).toByteArray(Charsets.UTF_8))
     }
 
     companion object {
 
-        private val GSON = Gson()
+        private val gson = Gson()
 
         fun fromMessage(message: Message): NearbyMessage {
             val nearbyMessageString = String(message.content).trim { it <= ' ' }
 
-            return GSON.fromJson(
+            return gson.fromJson(
                 String(nearbyMessageString.toByteArray(Charsets.UTF_8)),
                 NearbyMessage::class.java
             )

--- a/app/src/main/kotlin/de/cineaste/android/fragment/BaseListFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/BaseListFragment.kt
@@ -138,7 +138,10 @@ abstract class BaseListFragment : Fragment(), ItemClickListener, BaseListAdapter
         setHasOptionsMenu(true)
         if (savedInstanceState != null) {
             val currentState =
-                savedInstanceState.getString(WatchState.WATCH_STATE_TYPE.name, WatchState.WATCH_STATE.name)
+                savedInstanceState.getString(
+                    WatchState.WATCH_STATE_TYPE.name,
+                    WatchState.WATCH_STATE.name
+                )
             this.watchState = getWatchState(currentState)
         }
 

--- a/app/src/main/kotlin/de/cineaste/android/fragment/BaseListFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/BaseListFragment.kt
@@ -61,8 +61,11 @@ abstract class BaseListFragment : Fragment(), ItemClickListener, BaseListAdapter
         super.setArguments(args)
         args?.let {
             watchState = getWatchState(
-                    args.getString(WatchState.WATCH_STATE_TYPE.name,
-                            WatchState.WATCH_STATE.name))
+                args.getString(
+                    WatchState.WATCH_STATE_TYPE.name,
+                    WatchState.WATCH_STATE.name
+                )
+            )
         }
     }
 
@@ -134,7 +137,8 @@ abstract class BaseListFragment : Fragment(), ItemClickListener, BaseListAdapter
         super.onCreate(savedInstanceState)
         setHasOptionsMenu(true)
         if (savedInstanceState != null) {
-            val currentState = savedInstanceState.getString(WatchState.WATCH_STATE_TYPE.name, WatchState.WATCH_STATE.name)
+            val currentState =
+                savedInstanceState.getString(WatchState.WATCH_STATE_TYPE.name, WatchState.WATCH_STATE.name)
             this.watchState = getWatchState(currentState)
         }
 
@@ -235,9 +239,10 @@ abstract class BaseListFragment : Fragment(), ItemClickListener, BaseListAdapter
         val intent = createIntent(itemId, state, activity)
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
-            val options = makeSceneTransitionAnimation(activity,
-                    Pair.create(views[0], "card"),
-                    Pair.create(views[1], "poster")
+            val options = makeSceneTransitionAnimation(
+                activity,
+                Pair.create(views[0], "card"),
+                Pair.create(views[1], "poster")
             )
             activity.startActivity(intent, options.toBundle())
         } else {

--- a/app/src/main/kotlin/de/cineaste/android/fragment/BaseListFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/BaseListFragment.kt
@@ -186,8 +186,8 @@ abstract class BaseListFragment : Fragment(), ItemClickListener, BaseListAdapter
                         UserInputFragment().show(fragmentManager, "")
                     }
                 }
-                R.id.filterAlphabetical -> reorderLists(BaseListFragment.FilterType.ALPHABETICAL)
-                R.id.filterReleaseDate -> reorderLists(BaseListFragment.FilterType.RELEASE_DATE)
+                R.id.filterAlphabetical -> reorderLists(FilterType.ALPHABETICAL)
+                R.id.filterReleaseDate -> reorderLists(FilterType.RELEASE_DATE)
                 R.id.filterRunTime -> reorderLists(FilterType.RUNTIME)
             }
         }
@@ -234,7 +234,7 @@ abstract class BaseListFragment : Fragment(), ItemClickListener, BaseListAdapter
         val activity = activity ?: return
         val intent = createIntent(itemId, state, activity)
 
-        if (android.os.Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
             val options = makeSceneTransitionAnimation(activity,
                     Pair.create(views[0], "card"),
                     Pair.create(views[1], "poster")

--- a/app/src/main/kotlin/de/cineaste/android/fragment/MovieListFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/MovieListFragment.kt
@@ -60,8 +60,10 @@ class MovieListFragment : BaseListFragment() {
         customRecyclerView.adapter = movieListAdapter
 
         val divider = ContextCompat.getDrawable(customRecyclerView.context, R.drawable.divider)
-        val itemDecor = DividerItemDecoration(customRecyclerView.context,
-            layoutManager.orientation)
+        val itemDecor = DividerItemDecoration(
+            customRecyclerView.context,
+            layoutManager.orientation
+        )
         divider?.let {
             itemDecor.setDrawable(it)
         }

--- a/app/src/main/kotlin/de/cineaste/android/fragment/MovieListFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/MovieListFragment.kt
@@ -38,9 +38,19 @@ class MovieListFragment : BaseListFragment() {
 
     override val correctCallBack: ItemTouchHelper.Callback
         get() = if (watchState == WatchState.WATCH_STATE) {
-            WatchlistMovieTouchHelperCallback(layoutManager, movieListAdapter, customRecyclerView, resources)
+            WatchlistMovieTouchHelperCallback(
+                layoutManager,
+                movieListAdapter,
+                customRecyclerView,
+                resources
+            )
         } else {
-            HistoryListMovieTouchHelperCallback(layoutManager, movieListAdapter, customRecyclerView, resources)
+            HistoryListMovieTouchHelperCallback(
+                layoutManager,
+                movieListAdapter,
+                customRecyclerView,
+                resources
+            )
         }
 
     override fun updateAdapter() {

--- a/app/src/main/kotlin/de/cineaste/android/fragment/MovieListFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/MovieListFragment.kt
@@ -76,11 +76,11 @@ class MovieListFragment : BaseListFragment() {
         (customRecyclerView.adapter as MovieListAdapter).filter.filter(newText)
     }
 
-    override fun reorderEntries(filterType: BaseListFragment.FilterType) {
+    override fun reorderEntries(filterType: FilterType) {
         when (filterType) {
-            BaseListFragment.FilterType.ALPHABETICAL -> movieListAdapter.orderAlphabetical()
-            BaseListFragment.FilterType.RELEASE_DATE -> movieListAdapter.orderByReleaseDate()
-            BaseListFragment.FilterType.RUNTIME -> movieListAdapter.orderByRuntime()
+            FilterType.ALPHABETICAL -> movieListAdapter.orderAlphabetical()
+            FilterType.RELEASE_DATE -> movieListAdapter.orderByReleaseDate()
+            FilterType.RUNTIME -> movieListAdapter.orderByRuntime()
         }
 
         movieListAdapter.notifyDataSetChanged()

--- a/app/src/main/kotlin/de/cineaste/android/fragment/SeasonDetailFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/SeasonDetailFragment.kt
@@ -100,13 +100,21 @@ class SeasonDetailFragment : Fragment(), EpisodeViewHolder.OnEpisodeWatchStateCh
         adapter.update(episodes)
     }
 
-    override fun showDescription(showDescription: ImageButton, hideDescription: ImageButton, description: TextView) {
+    override fun showDescription(
+        showDescription: ImageButton,
+        hideDescription: ImageButton,
+        description: TextView
+    ) {
         showDescription.visibility = View.INVISIBLE
         hideDescription.visibility = View.VISIBLE
         description.visibility = View.VISIBLE
     }
 
-    override fun hideDescription(showDescription: ImageButton, hideDescription: ImageButton, description: TextView) {
+    override fun hideDescription(
+        showDescription: ImageButton,
+        hideDescription: ImageButton,
+        description: TextView
+    ) {
         showDescription.visibility = View.VISIBLE
         hideDescription.visibility = View.INVISIBLE
         description.visibility = View.GONE

--- a/app/src/main/kotlin/de/cineaste/android/fragment/SeasonDetailFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/SeasonDetailFragment.kt
@@ -18,7 +18,8 @@ import de.cineaste.android.database.dbHelper.SeriesDbHelper
 import de.cineaste.android.entity.series.Episode
 import de.cineaste.android.viewholder.series.EpisodeViewHolder
 
-class SeasonDetailFragment : Fragment(), EpisodeViewHolder.OnEpisodeWatchStateChangeListener, EpisodeViewHolder.OnDescriptionShowToggleListener {
+class SeasonDetailFragment : Fragment(), EpisodeViewHolder.OnEpisodeWatchStateChangeListener,
+    EpisodeViewHolder.OnDescriptionShowToggleListener {
 
     private var seriesId: Long = 0
     private var seasonId: Long = 0

--- a/app/src/main/kotlin/de/cineaste/android/fragment/SeriesListFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/SeriesListFragment.kt
@@ -39,7 +39,13 @@ class SeriesListFragment : BaseListFragment(), SeriesListAdapter.OnEpisodeWatche
 
     override val correctCallBack: ItemTouchHelper.Callback
         get() = if (watchState == WatchState.WATCH_STATE) {
-            WatchlistSeriesTouchHelperCallback(resources, layoutManager, customRecyclerView, seriesListAdapter, activity!!)
+            WatchlistSeriesTouchHelperCallback(
+                resources,
+                layoutManager,
+                customRecyclerView,
+                seriesListAdapter,
+                activity!!
+            )
         } else {
             HistoryListSeriesTouchHelperCallback(resources, layoutManager, customRecyclerView, seriesListAdapter)
         }
@@ -93,7 +99,8 @@ class SeriesListFragment : BaseListFragment(), SeriesListAdapter.OnEpisodeWatche
         when (filterType) {
             FilterType.ALPHABETICAL -> seriesListAdapter.orderAlphabetical()
             FilterType.RELEASE_DATE -> seriesListAdapter.orderByReleaseDate()
-            else -> { }
+            else -> {
+            }
         }
 
         seriesListAdapter.notifyDataSetChanged()

--- a/app/src/main/kotlin/de/cineaste/android/fragment/SeriesListFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/SeriesListFragment.kt
@@ -89,10 +89,10 @@ class SeriesListFragment : BaseListFragment(), SeriesListAdapter.OnEpisodeWatche
         (customRecyclerView.adapter as SeriesListAdapter).filter.filter(newText)
     }
 
-    override fun reorderEntries(filterType: BaseListFragment.FilterType) {
+    override fun reorderEntries(filterType: FilterType) {
         when (filterType) {
-            BaseListFragment.FilterType.ALPHABETICAL -> seriesListAdapter.orderAlphabetical()
-            BaseListFragment.FilterType.RELEASE_DATE -> seriesListAdapter.orderByReleaseDate()
+            FilterType.ALPHABETICAL -> seriesListAdapter.orderAlphabetical()
+            FilterType.RELEASE_DATE -> seriesListAdapter.orderByReleaseDate()
             else -> { }
         }
 

--- a/app/src/main/kotlin/de/cineaste/android/fragment/SeriesListFragment.kt
+++ b/app/src/main/kotlin/de/cineaste/android/fragment/SeriesListFragment.kt
@@ -47,7 +47,12 @@ class SeriesListFragment : BaseListFragment(), SeriesListAdapter.OnEpisodeWatche
                 activity!!
             )
         } else {
-            HistoryListSeriesTouchHelperCallback(resources, layoutManager, customRecyclerView, seriesListAdapter)
+            HistoryListSeriesTouchHelperCallback(
+                resources,
+                layoutManager,
+                customRecyclerView,
+                seriesListAdapter
+            )
         }
 
     override fun onEpisodeWatchedClick(series: Series, position: Int) {

--- a/app/src/main/kotlin/de/cineaste/android/network/MovieLoader.kt
+++ b/app/src/main/kotlin/de/cineaste/android/network/MovieLoader.kt
@@ -96,14 +96,15 @@ class MovieLoader(context: Context) {
         }
 
         return Movie(
-                id,
-                posterPath,
-                title,
-                runtime,
-                voteAverage,
-                voteCount,
-                description,
-                releaseDate = releaseDate)
+            id,
+            posterPath,
+            title,
+            runtime,
+            voteAverage,
+            voteCount,
+            description,
+            releaseDate = releaseDate
+        )
     }
 
     private fun getReleaseDates(jsonString: JsonObject): HashMap<String, ReleaseDate> {

--- a/app/src/main/kotlin/de/cineaste/android/network/MovieLoader.kt
+++ b/app/src/main/kotlin/de/cineaste/android/network/MovieLoader.kt
@@ -120,7 +120,10 @@ class MovieLoader(context: Context) {
     }
 
     // Type 3 means only cinema release dates
-    private fun getOnlyType3Dates(dates: HashMap<String, ReleaseDate>, language: Locale): ReleaseDateType? {
+    private fun getOnlyType3Dates(
+        dates: HashMap<String, ReleaseDate>,
+        language: Locale
+    ): ReleaseDateType? {
         val date = dates[language.country]
 
         date?.let {

--- a/app/src/main/kotlin/de/cineaste/android/network/NetworkClient.kt
+++ b/app/src/main/kotlin/de/cineaste/android/network/NetworkClient.kt
@@ -35,7 +35,7 @@ class NetworkClient {
                     callback.onFailure()
                 }
                 callback.onSuccess(
-                        NetworkResponse(response.body()?.charStream())
+                    NetworkResponse(response.body()?.charStream())
                 )
             }
         })
@@ -55,7 +55,7 @@ class NetworkClient {
                     callback.onFailure()
                 }
                 callback.onSuccess(
-                        NetworkResponse(response.body()?.charStream())
+                    NetworkResponse(response.body()?.charStream())
                 )
             }
         })

--- a/app/src/main/kotlin/de/cineaste/android/network/SeriesLoader.kt
+++ b/app/src/main/kotlin/de/cineaste/android/network/SeriesLoader.kt
@@ -51,20 +51,22 @@ class SeriesLoader(context: Context) {
         seriesId: Long,
         callback: SeriesCallback
     ) {
-        client.addRequest(getSeasonRequest(seriesId, season.seasonNumber), object : NetworkCallback {
-            override fun onFailure() {
-                callback.onFailure()
-            }
-
-            override fun onSuccess(response: NetworkResponse) {
-                responseCounter.countDown()
-                val episodes = parseResponse(response)
-                for (episode in episodes) {
-                    episode.seasonId = season.id
+        client.addRequest(
+            getSeasonRequest(seriesId, season.seasonNumber),
+            object : NetworkCallback {
+                override fun onFailure() {
+                    callback.onFailure()
                 }
-                season.episodes = episodes
-            }
-        })
+
+                override fun onSuccess(response: NetworkResponse) {
+                    responseCounter.countDown()
+                    val episodes = parseResponse(response)
+                    for (episode in episodes) {
+                        episode.seasonId = season.id
+                    }
+                    season.episodes = episodes
+                }
+            })
     }
 
     private fun parseResponse(response: NetworkResponse): List<Episode> {

--- a/app/src/main/kotlin/de/cineaste/android/network/SeriesLoader.kt
+++ b/app/src/main/kotlin/de/cineaste/android/network/SeriesLoader.kt
@@ -44,7 +44,13 @@ class SeriesLoader(context: Context) {
         })
     }
 
-    private fun loadEpisodesOfSeason(responseCounter: CountDownLatch, season: Season, client: NetworkClient, seriesId: Long, callback: SeriesCallback) {
+    private fun loadEpisodesOfSeason(
+        responseCounter: CountDownLatch,
+        season: Season,
+        client: NetworkClient,
+        seriesId: Long,
+        callback: SeriesCallback
+    ) {
         client.addRequest(getSeasonRequest(seriesId, season.seasonNumber), object : NetworkCallback {
             override fun onFailure() {
                 callback.onFailure()

--- a/app/src/main/kotlin/de/cineaste/android/util/Constants.kt
+++ b/app/src/main/kotlin/de/cineaste/android/util/Constants.kt
@@ -6,7 +6,8 @@ interface Constants {
         const val DATABASE_VERSION = 4
         const val DATABASE_NAME = "cineaste.db"
 
-        private const val POSTER_BASE_URI = "https://image.tmdb.org/t/p/%s<posterName>?api_key=<API_KEY>"
+        private const val POSTER_BASE_URI =
+            "https://image.tmdb.org/t/p/%s<posterName>?api_key=<API_KEY>"
         val POSTER_URI_SMALL = String.format(POSTER_BASE_URI, "w342")
         val POSTER_URI_ORIGINAL = String.format(POSTER_BASE_URI, "original")
 

--- a/app/src/main/kotlin/de/cineaste/android/util/CustomRecyclerView.kt
+++ b/app/src/main/kotlin/de/cineaste/android/util/CustomRecyclerView.kt
@@ -18,7 +18,11 @@ class CustomRecyclerView : RecyclerView {
 
     constructor(context: Context, attrs: AttributeSet?) : super(context, attrs)
 
-    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(context, attrs, defStyle)
+    constructor(context: Context, attrs: AttributeSet?, defStyle: Int) : super(
+        context,
+        attrs,
+        defStyle
+    )
 
     override fun computeVerticalScrollRange(): Int {
         return if (isScrollingEnabled) super.computeVerticalScrollRange() else 0

--- a/app/src/main/kotlin/de/cineaste/android/util/DateAwareGson.kt
+++ b/app/src/main/kotlin/de/cineaste/android/util/DateAwareGson.kt
@@ -24,7 +24,11 @@ object DateAwareGson {
             val df: DateFormat = SimpleDateFormat("yyyy-MM-dd", Locale.ENGLISH)
 
             @Throws(JsonParseException::class)
-            override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Date? {
+            override fun deserialize(
+                json: JsonElement,
+                typeOfT: Type,
+                context: JsonDeserializationContext
+            ): Date? {
                 return try {
                     df.parse(json.asString)
                 } catch (e: ParseException) {
@@ -45,7 +49,11 @@ object ExtendedDateAwareGson {
             val df: DateFormat = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'", Locale.ENGLISH)
 
             @Throws(JsonParseException::class)
-            override fun deserialize(json: JsonElement, typeOfT: Type, context: JsonDeserializationContext): Date? {
+            override fun deserialize(
+                json: JsonElement,
+                typeOfT: Type,
+                context: JsonDeserializationContext
+            ): Date? {
                 return try {
                     df.parse(json.asString)
                 } catch (e: ParseException) {

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/BaseViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/BaseViewHolder.kt
@@ -14,7 +14,11 @@ import java.text.SimpleDateFormat
 import java.util.Date
 import java.util.Locale
 
-abstract class BaseViewHolder protected constructor(protected val view: View, protected val listener: ItemClickListener, private val context: Context) : RecyclerView.ViewHolder(view) {
+abstract class BaseViewHolder protected constructor(
+    protected val view: View,
+    protected val listener: ItemClickListener,
+    private val context: Context
+) : RecyclerView.ViewHolder(view) {
 
     protected val title: TextView = view.findViewById(R.id.title)
     protected val resources: Resources = context.resources
@@ -22,13 +26,13 @@ abstract class BaseViewHolder protected constructor(protected val view: View, pr
 
     protected fun setPoster(posterName: String?) {
         val posterUri = Constants.POSTER_URI_SMALL
-                .replace("<posterName>", posterName ?: "/")
-                .replace("<API_KEY>", context.getString(R.string.movieKey))
+            .replace("<posterName>", posterName ?: "/")
+            .replace("<API_KEY>", context.getString(R.string.movieKey))
         Picasso.get()
-                .load(posterUri)
-                .resize(222, 334)
-                .error(R.drawable.placeholder_poster)
-                .into(poster)
+            .load(posterUri)
+            .resize(222, 334)
+            .error(R.drawable.placeholder_poster)
+            .into(poster)
     }
 
     protected fun convertDate(date: Date): String {

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/movie/AbstractMovieViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/movie/AbstractMovieViewHolder.kt
@@ -9,7 +9,8 @@ import de.cineaste.android.entity.movie.Movie
 import de.cineaste.android.listener.ItemClickListener
 import de.cineaste.android.viewholder.BaseViewHolder
 
-abstract class AbstractMovieViewHolder(itemView: View, context: Context, listener: ItemClickListener) : BaseViewHolder(itemView, listener, context) {
+abstract class AbstractMovieViewHolder(itemView: View, context: Context, listener: ItemClickListener) :
+    BaseViewHolder(itemView, listener, context) {
 
     private val movieReleaseDate: TextView = itemView.findViewById(R.id.movieReleaseDate)
     lateinit var movieRuntime: TextView

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/movie/AbstractMovieViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/movie/AbstractMovieViewHolder.kt
@@ -9,7 +9,11 @@ import de.cineaste.android.entity.movie.Movie
 import de.cineaste.android.listener.ItemClickListener
 import de.cineaste.android.viewholder.BaseViewHolder
 
-abstract class AbstractMovieViewHolder(itemView: View, context: Context, listener: ItemClickListener) :
+abstract class AbstractMovieViewHolder(
+    itemView: View,
+    context: Context,
+    listener: ItemClickListener
+) :
     BaseViewHolder(itemView, listener, context) {
 
     private val movieReleaseDate: TextView = itemView.findViewById(R.id.movieReleaseDate)

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/movie/MovieSearchViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/movie/MovieSearchViewHolder.kt
@@ -9,7 +9,12 @@ import de.cineaste.android.adapter.movie.MovieSearchQueryAdapter
 import de.cineaste.android.entity.movie.Movie
 import de.cineaste.android.listener.ItemClickListener
 
-class MovieSearchViewHolder(itemView: View, context: Context, private val movieStateChange: MovieSearchQueryAdapter.OnMovieStateChange, listener: ItemClickListener) : AbstractMovieViewHolder(itemView, context, listener) {
+class MovieSearchViewHolder(
+    itemView: View,
+    context: Context,
+    private val movieStateChange: MovieSearchQueryAdapter.OnMovieStateChange,
+    listener: ItemClickListener
+) : AbstractMovieViewHolder(itemView, context, listener) {
 
     private val addToWatchlistButton: Button = itemView.findViewById(R.id.to_watchlist_button)
     private val movieWatchedButton: Button = itemView.findViewById(R.id.history_button)

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/movie/MovieViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/movie/MovieViewHolder.kt
@@ -9,7 +9,8 @@ import de.cineaste.android.R
 import de.cineaste.android.entity.movie.Movie
 import de.cineaste.android.listener.ItemClickListener
 
-class MovieViewHolder(itemView: View, context: Context, listener: ItemClickListener) : AbstractMovieViewHolder(itemView, context, listener) {
+class MovieViewHolder(itemView: View, context: Context, listener: ItemClickListener) :
+    AbstractMovieViewHolder(itemView, context, listener) {
 
     private val movieVote: TextView = itemView.findViewById(R.id.movie_vote)
 
@@ -20,8 +21,10 @@ class MovieViewHolder(itemView: View, context: Context, listener: ItemClickListe
 
         movieRuntime.text = resources.getString(R.string.runtime, movie.runtime)
         view.setOnClickListener {
-            listener.onItemClickListener(movie.id,
-                    arrayOf(view, poster, title, movieRuntime, movieVote))
+            listener.onItemClickListener(
+                movie.id,
+                arrayOf(view, poster, title, movieRuntime, movieVote)
+            )
         }
     }
 

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/AbstractSeriesViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/AbstractSeriesViewHolder.kt
@@ -10,7 +10,8 @@ import de.cineaste.android.entity.series.Series
 import de.cineaste.android.listener.ItemClickListener
 import de.cineaste.android.viewholder.BaseViewHolder
 
-abstract class AbstractSeriesViewHolder(itemView: View, listener: ItemClickListener, context: Context) : BaseViewHolder(itemView, listener, context) {
+abstract class AbstractSeriesViewHolder(itemView: View, listener: ItemClickListener, context: Context) :
+    BaseViewHolder(itemView, listener, context) {
 
     private val vote: TextView = itemView.findViewById(R.id.vote)
 

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/AbstractSeriesViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/AbstractSeriesViewHolder.kt
@@ -10,7 +10,11 @@ import de.cineaste.android.entity.series.Series
 import de.cineaste.android.listener.ItemClickListener
 import de.cineaste.android.viewholder.BaseViewHolder
 
-abstract class AbstractSeriesViewHolder(itemView: View, listener: ItemClickListener, context: Context) :
+abstract class AbstractSeriesViewHolder(
+    itemView: View,
+    listener: ItemClickListener,
+    context: Context
+) :
     BaseViewHolder(itemView, listener, context) {
 
     private val vote: TextView = itemView.findViewById(R.id.vote)

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/EpisodeViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/EpisodeViewHolder.kt
@@ -33,6 +33,7 @@ class EpisodeViewHolder(
             hideDescription: ImageButton,
             description: TextView
         )
+
         fun hideDescription(
             showDescription: ImageButton,
             hideDescription: ImageButton,
@@ -59,7 +60,11 @@ class EpisodeViewHolder(
         }
 
         hideDescription.setOnClickListener {
-            onDescriptionShowToggleListener.hideDescription(showDescription, hideDescription, description)
+            onDescriptionShowToggleListener.hideDescription(
+                showDescription,
+                hideDescription,
+                description
+            )
         }
 
         checkBox.setOnClickListener { onEpisodeWatchStateChangeListener.watchStateChanged(episode) }

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/EpisodeViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/EpisodeViewHolder.kt
@@ -10,7 +10,12 @@ import android.widget.TextView
 import de.cineaste.android.R
 import de.cineaste.android.entity.series.Episode
 
-class EpisodeViewHolder(itemView: View, private val onEpisodeWatchStateChangeListener: OnEpisodeWatchStateChangeListener, private val onDescriptionShowToggleListener: OnDescriptionShowToggleListener, private val context: Context) : RecyclerView.ViewHolder(itemView) {
+class EpisodeViewHolder(
+    itemView: View,
+    private val onEpisodeWatchStateChangeListener: OnEpisodeWatchStateChangeListener,
+    private val onDescriptionShowToggleListener: OnDescriptionShowToggleListener,
+    private val context: Context
+) : RecyclerView.ViewHolder(itemView) {
 
     private val episodeTitle: TextView = itemView.findViewById(R.id.episodeTitle)
     private val description: TextView = itemView.findViewById(R.id.description)
@@ -37,7 +42,13 @@ class EpisodeViewHolder(itemView: View, private val onEpisodeWatchStateChangeLis
             description.text = episode.description
         }
 
-        showDescription.setOnClickListener { onDescriptionShowToggleListener.showDescription(showDescription, hideDescription, description) }
+        showDescription.setOnClickListener {
+            onDescriptionShowToggleListener.showDescription(
+                showDescription,
+                hideDescription,
+                description
+            )
+        }
 
         hideDescription.setOnClickListener {
             onDescriptionShowToggleListener.hideDescription(showDescription, hideDescription, description)

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/EpisodeViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/EpisodeViewHolder.kt
@@ -28,8 +28,16 @@ class EpisodeViewHolder(
     }
 
     interface OnDescriptionShowToggleListener {
-        fun showDescription(showDescription: ImageButton, hideDescription: ImageButton, description: TextView)
-        fun hideDescription(showDescription: ImageButton, hideDescription: ImageButton, description: TextView)
+        fun showDescription(
+            showDescription: ImageButton,
+            hideDescription: ImageButton,
+            description: TextView
+        )
+        fun hideDescription(
+            showDescription: ImageButton,
+            hideDescription: ImageButton,
+            description: TextView
+        )
     }
 
     fun assignData(episode: Episode) {

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeasonViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeasonViewHolder.kt
@@ -31,8 +31,10 @@ class SeasonViewHolder(
     private val resources: Resources = context.resources
 
     fun assignData(season: Season) {
-        seasonNumber.text = resources.getString(R.string.currentSeason, season.seasonNumber.toString())
-        numberOfEpisodes.text = resources.getString(R.string.episodes, season.episodeCount.toString())
+        seasonNumber.text =
+            resources.getString(R.string.currentSeason, season.seasonNumber.toString())
+        numberOfEpisodes.text =
+            resources.getString(R.string.episodes, season.episodeCount.toString())
         if (season.releaseDate == null) {
             releaseDate.visibility = View.GONE
         } else {

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeasonViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeasonViewHolder.kt
@@ -49,13 +49,13 @@ class SeasonViewHolder(
     private fun setMoviePoster(season: Season) {
         val posterName = season.posterPath
         val posterUri = Constants.POSTER_URI_SMALL
-                .replace("<posterName>", posterName ?: "/")
-                .replace("<API_KEY>", context.getString(R.string.movieKey))
+            .replace("<posterName>", posterName ?: "/")
+            .replace("<API_KEY>", context.getString(R.string.movieKey))
         Picasso.get()
-                .load(posterUri)
-                .resize(342, 513)
-                .error(R.drawable.placeholder_poster)
-                .into(poster)
+            .load(posterUri)
+            .resize(342, 513)
+            .error(R.drawable.placeholder_poster)
+            .into(poster)
     }
 
     private fun convertDate(date: Date?): String {

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeriesSearchViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeriesSearchViewHolder.kt
@@ -10,7 +10,12 @@ import de.cineaste.android.adapter.series.SeriesSearchQueryAdapter
 import de.cineaste.android.entity.series.Series
 import de.cineaste.android.listener.ItemClickListener
 
-class SeriesSearchViewHolder(itemView: View, listener: ItemClickListener, context: Context, private val seriesStateChange: SeriesSearchQueryAdapter.OnSeriesStateChange) : AbstractSeriesViewHolder(itemView, listener, context) {
+class SeriesSearchViewHolder(
+    itemView: View,
+    listener: ItemClickListener,
+    context: Context,
+    private val seriesStateChange: SeriesSearchQueryAdapter.OnSeriesStateChange
+) : AbstractSeriesViewHolder(itemView, listener, context) {
 
     private val releaseDate: TextView = itemView.findViewById(R.id.releaseDate)
     private val addToWatchlistButton: Button = itemView.findViewById(R.id.to_watchlist_button)

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeriesSearchViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeriesSearchViewHolder.kt
@@ -41,6 +41,11 @@ class SeriesSearchViewHolder(
             seriesStateChange.onSeriesStateChangeListener(series, v.id, index)
         }
 
-        view.setOnClickListener { view -> listener.onItemClickListener(series.id, arrayOf(view, poster)) }
+        view.setOnClickListener { view ->
+            listener.onItemClickListener(
+                series.id,
+                arrayOf(view, poster)
+            )
+        }
     }
 }

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeriesViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeriesViewHolder.kt
@@ -12,7 +12,13 @@ import de.cineaste.android.entity.series.Series
 import de.cineaste.android.fragment.WatchState
 import de.cineaste.android.listener.ItemClickListener
 
-class SeriesViewHolder(itemView: View, listener: ItemClickListener, context: Context, state: WatchState, private val onEpisodeWatchedClickListener: SeriesListAdapter.OnEpisodeWatchedClickListener) : AbstractSeriesViewHolder(itemView, listener, context) {
+class SeriesViewHolder(
+    itemView: View,
+    listener: ItemClickListener,
+    context: Context,
+    state: WatchState,
+    private val onEpisodeWatchedClickListener: SeriesListAdapter.OnEpisodeWatchedClickListener
+) : AbstractSeriesViewHolder(itemView, listener, context) {
 
     private val seasons: TextView = itemView.findViewById(R.id.season)
     private val currentStatus: TextView = itemView.findViewById(R.id.current)
@@ -28,9 +34,11 @@ class SeriesViewHolder(itemView: View, listener: ItemClickListener, context: Con
         setBaseInformation(series)
 
         seasons.text = resources.getString(R.string.seasons, series.numberOfSeasons.toString())
-        currentStatus.text = resources.getString(R.string.currentStatus,
-                series.currentNumberOfSeason.toString(),
-                series.currentNumberOfEpisode.toString())
+        currentStatus.text = resources.getString(
+            R.string.currentStatus,
+            series.currentNumberOfSeason.toString(),
+            series.currentNumberOfEpisode.toString()
+        )
 
         episodeSeen.setOnClickListener { onEpisodeWatchedClickListener.onEpisodeWatchedClick(series, position) }
 

--- a/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeriesViewHolder.kt
+++ b/app/src/main/kotlin/de/cineaste/android/viewholder/series/SeriesViewHolder.kt
@@ -40,9 +40,19 @@ class SeriesViewHolder(
             series.currentNumberOfEpisode.toString()
         )
 
-        episodeSeen.setOnClickListener { onEpisodeWatchedClickListener.onEpisodeWatchedClick(series, position) }
+        episodeSeen.setOnClickListener {
+            onEpisodeWatchedClickListener.onEpisodeWatchedClick(
+                series,
+                position
+            )
+        }
 
-        view.setOnClickListener { view -> listener.onItemClickListener(series.id, arrayOf(view, poster, title)) }
+        view.setOnClickListener { view ->
+            listener.onItemClickListener(
+                series.id,
+                arrayOf(view, poster, title)
+            )
+        }
     }
 
     fun onItemSelected() {

--- a/app/src/main/res/drawable/circle.xml
+++ b/app/src/main/res/drawable/circle.xml
@@ -1,8 +1,8 @@
 <?xml version="1.0" encoding="utf-8"?>
 <layer-list xmlns:android="http://schemas.android.com/apk/res/android">
     <item>
-        <shape xmlns:android="http://schemas.android.com/apk/res/android"
-            android:shape="oval">
+        <shape
+                android:shape="oval">
 
             <solid android:color="@color/colorAccent" />
 

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -8,8 +8,8 @@
 
     <include layout="@layout/toolbar" />
 
-    <WebView xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/webview"
+    <WebView
+            android:id="@+id/webview"
         android:layout_width="match_parent" android:layout_height="match_parent"/>
 </LinearLayout>
 

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -9,7 +9,7 @@
     <include layout="@layout/toolbar" />
 
     <WebView
-            android:id="@+id/webview"
+            android:id="@+id/webView"
         android:layout_width="match_parent" android:layout_height="match_parent"/>
 </LinearLayout>
 

--- a/app/src/main/res/layout/activity_movie_detail.xml
+++ b/app/src/main/res/layout/activity_movie_detail.xml
@@ -98,7 +98,7 @@
 
                     <TextView
                         android:id="@+id/movieReleaseDate"
-                        style="@style/cardviewDescriptionText"
+                        style="@style/cardViewDescriptionText"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:layout_marginStart="16dp"
@@ -121,7 +121,7 @@
 
                     <TextView
                         android:id="@+id/movieRuntime"
-                        style="@style/cardviewDescriptionText"
+                        style="@style/cardViewDescriptionText"
                         android:layout_width="0dp"
                         android:layout_height="wrap_content"
                         android:text="@string/runtime"

--- a/app/src/main/res/layout/activity_movie_night.xml
+++ b/app/src/main/res/layout/activity_movie_night.xml
@@ -9,9 +9,8 @@
 
     <include layout="@layout/toolbar"/>
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        xmlns:tools="http://schemas.android.com/tools"
-        android:layout_width="match_parent"
+    <RelativeLayout
+            android:layout_width="match_parent"
         android:layout_height="match_parent">
 
         <Button

--- a/app/src/main/res/layout/activity_season_detail.xml
+++ b/app/src/main/res/layout/activity_season_detail.xml
@@ -55,8 +55,8 @@
         </com.google.android.material.appbar.CollapsingToolbarLayout>
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.viewpager.widget.ViewPager xmlns:android="http://schemas.android.com/apk/res/android"
-                                         android:id="@+id/pager"
+    <androidx.viewpager.widget.ViewPager
+            android:id="@+id/pager"
                                          app:layout_behavior="@string/appbar_scrolling_view_behavior"
                                          android:layout_width="match_parent"
                                          android:layout_height="match_parent"

--- a/app/src/main/res/layout/card_episode.xml
+++ b/app/src/main/res/layout/card_episode.xml
@@ -18,8 +18,8 @@
         android:paddingStart="16dp"
         android:paddingTop="8dp">
 
-        <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-            android:layout_width="match_parent"
+        <RelativeLayout
+                android:layout_width="match_parent"
             android:layout_height="wrap_content">
 
             <CheckBox

--- a/app/src/main/res/layout/card_movie.xml
+++ b/app/src/main/res/layout/card_movie.xml
@@ -4,8 +4,7 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/b"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
-    android:background="@android:color/white">
+    android:layout_height="wrap_content">
 
     <ImageView
         android:id="@+id/poster_image_view"

--- a/app/src/main/res/layout/card_movie.xml
+++ b/app/src/main/res/layout/card_movie.xml
@@ -4,7 +4,8 @@
     xmlns:tools="http://schemas.android.com/tools"
     android:id="@+id/b"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content">
+    android:layout_height="wrap_content"
+    android:background="@android:color/white">
 
     <ImageView
         android:id="@+id/poster_image_view"

--- a/app/src/main/res/layout/card_movie.xml
+++ b/app/src/main/res/layout/card_movie.xml
@@ -29,7 +29,7 @@
 
     <TextView
         android:id="@+id/movieReleaseDate"
-        style="@style/cardviewDescriptionText"
+        style="@style/cardViewDescriptionText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"
@@ -53,7 +53,7 @@
 
     <TextView
         android:id="@+id/movieRuntime"
-        style="@style/cardviewDescriptionText"
+        style="@style/cardViewDescriptionText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:text="@string/runtime"
@@ -79,7 +79,7 @@
 
     <TextView
         android:id="@+id/movie_vote"
-        style="@style/cardviewDescriptionText"
+        style="@style/cardViewDescriptionText"
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         android:layout_marginStart="8dp"

--- a/app/src/main/res/layout/card_movie_search.xml
+++ b/app/src/main/res/layout/card_movie_search.xml
@@ -3,8 +3,8 @@
                                    android:id="@+id/card_view"
                                    style="@style/cardView">
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/relativeLayout"
+    <RelativeLayout
+            android:id="@+id/relativeLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/card_movie_search.xml
+++ b/app/src/main/res/layout/card_movie_search.xml
@@ -42,7 +42,7 @@
 
             <TextView
                 android:id="@+id/movieReleaseDate"
-                style="@style/cardviewDescriptionText"
+                style="@style/cardViewDescriptionText"
                 android:layout_width="match_parent"
                 android:layout_height="wrap_content"
                 android:text="@string/releaseDate"

--- a/app/src/main/res/layout/card_result.xml
+++ b/app/src/main/res/layout/card_result.xml
@@ -4,8 +4,8 @@
                                    style="@style/cardView"
                                    android:layout_margin="5dp">
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/relativeLayout"
+    <RelativeLayout
+            android:id="@+id/relativeLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/card_series.xml
+++ b/app/src/main/res/layout/card_series.xml
@@ -71,7 +71,7 @@
 
                     <TextView
                         android:id="@+id/vote"
-                        style="@style/cardviewDescriptionText"
+                        style="@style/cardViewDescriptionText"
                         android:layout_width="match_parent"
                         android:layout_height="wrap_content"
                         android:drawablePadding="4dp"

--- a/app/src/main/res/layout/card_series.xml
+++ b/app/src/main/res/layout/card_series.xml
@@ -8,8 +8,8 @@
                                    android:layout_marginRight="5dp"
                                    android:layout_marginEnd="5dp">
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/relativeLayout"
+    <RelativeLayout
+            android:id="@+id/relativeLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/card_series_search.xml
+++ b/app/src/main/res/layout/card_series_search.xml
@@ -4,8 +4,8 @@
                                    style="@style/cardView"
                                    android:layout_margin="5dp">
 
-    <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-        android:id="@+id/relativeLayout"
+    <RelativeLayout
+            android:id="@+id/relativeLayout"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 

--- a/app/src/main/res/layout/card_series_search.xml
+++ b/app/src/main/res/layout/card_series_search.xml
@@ -59,7 +59,7 @@
 
                 <TextView
                     android:id="@+id/vote"
-                    style="@style/cardviewDescriptionText"
+                    style="@style/cardViewDescriptionText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="0.5"
@@ -70,7 +70,7 @@
 
                 <TextView
                     android:id="@+id/releaseDate"
-                    style="@style/cardviewDescriptionText"
+                    style="@style/cardViewDescriptionText"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:layout_weight="0.5"

--- a/app/src/main/res/layout/fragment_user_input.xml
+++ b/app/src/main/res/layout/fragment_user_input.xml
@@ -14,7 +14,8 @@
         android:layout_marginStart="16dp"
         android:layout_marginTop="16dp"
         android:hint="@string/enter_username"
-        android:inputType="textPersonName" />
+        android:inputType="textPersonName"
+        android:autofillHints="username" />
 
     <Button
         android:id="@+id/ok_tv"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -6,7 +6,7 @@
         <item quantity="one">Movie: %d</item>
         <item quantity="other">Movies: %d</item>
     </plurals>
-    <string name="startMovieNight">Start Movienight</string>
+    <string name="startMovieNight">Start Movie Night</string>
     <string name="result">Result</string>
 
     <string name="enter_username">Your Username</string>

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -25,7 +25,7 @@
         <item name="cardElevation">5dp</item>
     </style>
 
-    <style name="cardviewDescriptionText">
+    <style name="cardViewDescriptionText">
         <item name="android:textColor">@color/backgroundColor</item>
     </style>
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
     ext.kotlin_version = '1.3.31'
-    ext.tools_version = '3.3.2'
+    ext.tools_version = '3.4.0'
     ext.build_tools_version = '28.0.3'
     ext.sdk_version = 28
     ext.ax_version = '1.0.0'

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 buildscript {
-    ext.kotlin_version = '1.3.21'
+    ext.kotlin_version = '1.3.31'
     ext.tools_version = '3.3.2'
     ext.build_tools_version = '28.0.3'
     ext.sdk_version = 28

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Sun Jan 20 11:50:39 CET 2019
+#Sat Apr 27 13:48:44 CEST 2019
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.1.1-all.zip


### PR DESCRIPTION
Run `./gradlew lint` to see all Android Lint Warnings. 

This PR fixes most of them:

- Remove redundant qualifier name
- Make variable private
- Replace negated `isEmpty` with `isNotEmpty`
- Remove unneeded import
- Reformat files
- Delete unneeded namespace declaration in xml files
- Add `autofillHints` for EditText
- Fix warning for not handling all switch cases

It also updates **kotlin version, gradle version and gradle dependencies**.

## Open warnings

There are still some open warnings. 
Maybe someone can help with them. 

### Correctness 

- [ ] 1 UnusedAttribute: Attribute unused on older versions (which should be suppressed)

### Performance

- [ ] 1 Overdraw: Overdraw: Painting regions more than once (which should be suppressed, because it is necessary)
- [ ] 3 UnusedResources: Unused resources

### Usability:Icons

- [ ]  1 IconDipSize: Icon density-independent size validation
