### PR TITLE
Update .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,5 +7,8 @@ android:
 licenses:
     - 'android-sdk-license-.+'
 
+before_install:
+  - yes | sdkmanager "platforms;android-28"
+
 script:
   ./gradlew ktlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
 language: android
+dist: trusty
 
+android:
+  components:
+    - build-tools-28.0.3
+    - android-28
 licenses:
     - 'android-sdk-license-.+'
-
-before_install:
-  - yes | sdkmanager "platforms;android-28"
-  - yes | sdkmanager “build-tools;28.0.3”
 
 script:
   ./gradlew ktlint

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,11 @@
 language: android
 
-android:
-  components:
-    - build-tools-28.0.3
-    - android-28
 licenses:
     - 'android-sdk-license-.+'
 
 before_install:
   - yes | sdkmanager "platforms;android-28"
+  - yes | sdkmanager “build-tools;28.0.3”
 
 script:
   ./gradlew ktlint


### PR DESCRIPTION
Use [trusty](https://docs.travis-ci.com/user/reference/trusty/#using-trusty) to fix CI. 

<details>
<summary>Error Log for the failure in the CI</summary>

```
FAILURE: Build failed with an exception.
* What went wrong:
A problem occurred configuring project ':app'.
> Failed to install the following Android SDK packages as some licences have not been accepted.
     build-tools;28.0.3 Android SDK Build-Tools 28.0.3
     platforms;android-28 Android SDK Platform 28
  To build this project, accept the SDK license agreements and install the missing components using the Android Studio SDK Manager.
  Alternatively, to transfer the license agreements from one workstation to another, see http://d.android.com/r/studio-ui/export-licenses.html
  
  Using Android SDK: /usr/local/android-sdk
```

</details>